### PR TITLE
Fetch achieved hardware sample rate after the audio session is activated

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2036,17 +2036,6 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
     result = AudioSessionSetProperty(kAudioSessionProperty_PreferredHardwareSampleRate, sizeof(sampleRate), &sampleRate);
     checkResult(result, "AudioSessionSetProperty(kAudioSessionProperty_PreferredHardwareSampleRate)");
     
-    // Fetch sample rate, in case we didn't get quite what we requested
-    Float64 achievedSampleRate;
-    UInt32 size = sizeof(achievedSampleRate);
-    result = AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate, &size, &achievedSampleRate);
-    checkResult(result, "AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate)");
-    if ( achievedSampleRate != sampleRate ) {
-        NSLog(@"Warning: Delivered sample rate is %f", achievedSampleRate);
-        _audioDescription.mSampleRate = achievedSampleRate;
-        [extraInfo appendFormat:@", sample rate %f", achievedSampleRate];
-    }
-    
     UInt32 inputAvailable = NO;
     if ( _inputEnabled ) {
         // See if input's available
@@ -2063,6 +2052,17 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
     // Start session
     checkResult(AudioSessionSetActive(true), "AudioSessionSetActive");
     
+    // Fetch sample rate, in case we didn't get quite what we requested
+    Float64 achievedSampleRate;
+    UInt32 size = sizeof(achievedSampleRate);
+    result = AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate, &size, &achievedSampleRate);
+    checkResult(result, "AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate)");
+    if ( achievedSampleRate != sampleRate ) {
+        NSLog(@"Warning: Delivered sample rate is %f", achievedSampleRate);
+        _audioDescription.mSampleRate = achievedSampleRate;
+        [extraInfo appendFormat:@", sample rate %f", achievedSampleRate];
+    }
+
     // Determine audio route
     CFStringRef route;
     size = sizeof(route);


### PR DESCRIPTION
Hi,

I had some trouble using a different sample rate than the default 44.1kHz. Setting a different sample rate in the audioDescription parameter of AEAudioController initWithAudioDescription:inputEnabled: always resulted in 44.1kHz.

As it turns out, one should fetch kAudioSessionProperty_PreferredHardwareSampleRate only after the audio session is activated: https://developer.apple.com/library/ios/#qa/qa1631/_index.html

Thanks for the project, it's saving me a lot of time!
