### PR TITLE
Housekeeping fix

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -803,14 +803,10 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
         _audioGraph = NULL;
     }
     
-    self.housekeepingTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(housekeeping) userInfo:nil repeats:YES];
-    
     return self;
 }
 
 - (void)dealloc {
-    [_housekeepingTimer invalidate];
-    self.housekeepingTimer = nil;
     
     self.lastError = nil;
     
@@ -909,7 +905,9 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
             return NO;
         }
     }
-    
+
+    self.housekeepingTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(housekeeping) userInfo:nil repeats:YES];
+
     return !hasError;
 }
 
@@ -936,6 +934,10 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
         [_pollThread release];
         _pollThread = nil;
     }
+    
+    [_housekeepingTimer invalidate];
+    self.housekeepingTimer = nil;
+
 }
 
 #pragma mark - Channel and channel group management


### PR DESCRIPTION
I noticed when running TAAE through Instruments on starting subsequent instances of AEAudioController, they weren't being released. housekeepingTimer was retaining the audioController instance, so dealloc was never getting called. I've moved the timer setup to [audioController start:] and the timer invalidate to [audioController stop] to resolve this.
