### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,11 @@ Built upon the efficient and low-latency Core Audio Remote IO system, and writte
 
 See http://theamazingaudioengine.com for details and http://theamazingaudioengine.com/doc for documentation.
 
-
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=TheEngineSample.xcodeproj&amp;target=TheEngineSample&amp;repo_url=git%3A%2F%2Fgithub.com%2FTheAmazingAudioEngine%2FTheAmazingAudioEngine.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
 License
 -------
 


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
