### PR TITLE
Adds utility method timestampWithSeconds:fromTimestamp to AEBlockScheduler.

### DIFF
--- a/TheAmazingAudioEngine/AEBlockScheduler.h
+++ b/TheAmazingAudioEngine/AEBlockScheduler.h
@@ -70,6 +70,11 @@ typedef void (^AEBlockSchedulerResponseBlock)();
 + (uint64_t)timestampWithSecondsFromNow:(NSTimeInterval)seconds;
 
 /*!
+ * Utility: Create a timestamp in host ticks the given number of seconds from a timestamp
+ */
++ (uint64_t)timestampWithSeconds:(NSTimeInterval)seconds fromTimestamp:(uint64_t)timeStamp;
+
+/*!
  * Utility: Determine the number of seconds until a given timestamp
  */
 + (NSTimeInterval)secondsUntilTimestamp:(uint64_t)timestamp;

--- a/TheAmazingAudioEngine/AEBlockScheduler.m
+++ b/TheAmazingAudioEngine/AEBlockScheduler.m
@@ -68,6 +68,11 @@ struct _schedule_t {
     return (timestamp - mach_absolute_time()) * __hostTicksToSeconds;
 }
 
++ (uint64_t)timestampWithSeconds:(NSTimeInterval)seconds fromTimestamp:(uint64_t)timeStamp
+{
+    return (timeStamp + (seconds * __secondsToHostTicks));
+}
+
 - (id)initWithAudioController:(AEAudioController *)audioController {
     if ( !(self = [super init]) ) return nil;
     


### PR DESCRIPTION
Small utility method to create a new timestamp in host ticks that is a given number of seconds after an existing timestamp.
