### PR TITLE
Discovering the preferred node format on audio unit filters

### DIFF
--- a/TheAmazingAudioEngine/AEAudioUnitFilter.m
+++ b/TheAmazingAudioEngine/AEAudioUnitFilter.m
@@ -1,5 +1,5 @@
 //
-//  AEAudioUnitFilter.m
+//  AEAudioUnitFilter.h
 //  TheAmazingAudioEngine
 //
 //  Created by Michael Tyson on 05/02/2013.
@@ -23,225 +23,64 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-#import "AEAudioUnitFilter.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#define checkResult(result,operation) (_checkResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
-static inline BOOL _checkResult(OSStatus result, const char *operation, const char* file, int line) {
-    if ( result != noErr ) {
-        int fourCC = CFSwapInt32HostToBig(result);
-        NSLog(@"%s:%d: %s result %d %08X %4.4s\n", file, line, operation, (int)result, (int)result, (char*)&fourCC);
-        return NO;
-    }
-    return YES;
-}
+#import <Foundation/Foundation.h>
+#import "TheAmazingAudioEngine.h"
 
-@interface AEAudioUnitFilter () {
-    AEAudioController *_audioController;
-    AudioComponentDescription _componentDescription;
-    BOOL _useDefaultInputFormat;
-    AUNode _node;
-    AudioUnit _audioUnit;
-    AUNode _inConverterNode;
-    AudioUnit _inConverterUnit;
-    AUNode _outConverterNode;
-    AudioUnit _outConverterUnit;
-    AUGraph _audioGraph;
-    AEAudioControllerFilterProducer _currentProducer;
-    void *_currentProducerToken;
-}
-@end
+/*!
+ * Audio Unit Filter
+ *
+ *  This class allows you to use Audio Units as filters. Provide an
+ *  AudioComponentDescription that describes the audio unit, and the
+ *  corresponding audio unit will be initialised, ready for use
+ *
+ */
+@interface AEAudioUnitFilter : NSObject <AEAudioFilter>
 
-@implementation AEAudioUnitFilter
-
+/*!
+ * Create a new Audio Unit filter
+ *
+ * @param audioComponentDescription The structure that identifies the audio unit
+ * @param audioController The audio controller
+ * @param error On output, if not NULL, will point to an error if a problem occurred
+ * @return The initialised filter, or nil if an error occurred
+ */
 - (id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
                    audioController:(AEAudioController*)audioController
-                             error:(NSError**)error {
-    return [self initWithComponentDescription:audioComponentDescription audioController:audioController useDefaultInputFormat:NO error:error];
-}
+                             error:(NSError**)error;
 
--(id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
-                  audioController:(AEAudioController *)audioController
-            useDefaultInputFormat:(BOOL)useDefaultInputFormat
-                            error:(NSError **)error {
-    if ( !(self = [super init]) ) return nil;
+/*!
+ * Create a new Audio Unit filter, using the default input audio description
+ *
+ * @param audioComponentDescription The structure that identifies the audio unit
+ * @param audioController The audio controller
+ * @param useDefaultInputFormat Whether to always use the audio unit's default input audio format.
+ *              This can be used as a workaround for audio units that misidentify the TAAE system
+ *              audio description as being compatible. Audio will automatically be converted from
+ *              the source audio format to this format.
+ * @param error On output, if not NULL, will point to an error if a problem occurred
+ * @return The initialised filter, or nil if an error occurred
+ */
+- (id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
+                   audioController:(AEAudioController*)audioController
+             useDefaultInputFormat:(BOOL)useDefaultInputFormat
+                             error:(NSError**)error;
 
-    // Create the node, and the audio unit
-    _audioController = audioController;
-    _componentDescription = audioComponentDescription;
-    _useDefaultInputFormat = useDefaultInputFormat;
-    _audioGraph = audioController.audioGraph;
-	
-    if ( ![self setup:error] ) {
-        [self release];
-        return nil;
-    }
-    
-    return self;
-}
+/*!
+ * The audio unit
+ */
+@property (nonatomic, readonly) AudioUnit audioUnit;
 
-- (BOOL)setup:(NSError**)error {
-    
-    OSStatus result;
-    if ( !checkResult(result=AUGraphAddNode(_audioGraph, &_componentDescription, &_node), "AUGraphAddNode") ||
-        !checkResult(result=AUGraphNodeInfo(_audioGraph, _node, NULL, &_audioUnit), "AUGraphNodeInfo") ) {
-        
-        if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't initialise audio unit" forKey:NSLocalizedDescriptionKey]];
-        return NO;
-    }
-    
-    // Try to set the output audio description
-    AudioStreamBasicDescription audioDescription = _audioController.audioDescription;
-    result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &audioDescription, sizeof(AudioStreamBasicDescription));
-    if ( result == kAudioUnitErr_FormatNotSupported ) {
-        // The audio description isn't supported. Assign modified default audio description, and create an audio converter.
-        AudioStreamBasicDescription defaultAudioDescription;
-        UInt32 size = sizeof(defaultAudioDescription);
-        AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, &size);
-        defaultAudioDescription.mSampleRate = audioDescription.mSampleRate;
-        AEAudioStreamBasicDescriptionSetChannelsPerFrame(&defaultAudioDescription, audioDescription.mChannelsPerFrame);
-        if ( !checkResult(result=AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, size), "AudioUnitSetProperty") ) {
-            if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Incompatible audio format" forKey:NSLocalizedDescriptionKey]];
-            return NO;
-        }
-        
-        AudioComponentDescription audioConverterDescription = AEAudioComponentDescriptionMake(kAudioUnitManufacturer_Apple, kAudioUnitType_FormatConverter, kAudioUnitSubType_AUConverter);
-        
-        if ( !checkResult(result=AUGraphAddNode(_audioGraph, &audioConverterDescription, &_outConverterNode), "AUGraphAddNode") ||
-            !checkResult(result=AUGraphNodeInfo(_audioGraph, _outConverterNode, NULL, &_outConverterUnit), "AUGraphNodeInfo") ||
-            !checkResult(result=AUGraphConnectNodeInput(_audioGraph, _node, 0, _outConverterNode, 0), "AUGraphConnectNodeInput") ||
-            !checkResult(result=AudioUnitSetProperty(_outConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ||
-            !checkResult(result=AudioUnitSetProperty(_outConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &audioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ) {
-            
-            if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
-            return NO;
-        }
-    }
-    
-    // Try to set the input audio description
-    audioDescription = _audioController.audioDescription;
-    
-    if ( !_useDefaultInputFormat ) {
-        result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription));
-    }
-    
-    if ( _useDefaultInputFormat || result == kAudioUnitErr_FormatNotSupported ) {
-        // The audio description isn't supported. Assign modified default audio description, and create an audio converter.
-        AudioStreamBasicDescription defaultAudioDescription;
-        UInt32 size = sizeof(defaultAudioDescription);
-        AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, &size);
-
-        if ( !checkResult(result=AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, size), "AudioUnitSetProperty") ) {
-            if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Incompatible audio format" forKey:NSLocalizedDescriptionKey]];
-            return NO;
-        }
-        
-        AudioComponentDescription audioConverterDescription = AEAudioComponentDescriptionMake(kAudioUnitManufacturer_Apple, kAudioUnitType_FormatConverter, kAudioUnitSubType_AUConverter);
-        
-        if ( !checkResult(result=AUGraphAddNode(_audioGraph, &audioConverterDescription, &_inConverterNode), "AUGraphAddNode") ||  !checkResult(result=AUGraphNodeInfo(_audioGraph, _inConverterNode, NULL, &_inConverterUnit), "AUGraphNodeInfo") || !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") || !checkResult(result=AUGraphConnectNodeInput(_audioGraph, _inConverterNode, 0, _node, 0), "AUGraphConnectNodeInput") || !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ) {
-            
-            if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
-            return NO;
-        }
-    }
-    
-    // Set the audio unit's input callback
-    // Setup render callback struct
-    AURenderCallbackStruct rcbs;
-    rcbs.inputProc = &audioUnitRenderCallback;
-    rcbs.inputProcRefCon = self;
-    checkResult(AudioUnitSetProperty(_inConverterUnit ? _inConverterUnit : _audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &rcbs, sizeof(rcbs)),
-                "AudioUnitSetProperty(kAudioUnitProperty_SetRenderCallback)");
-    
-    // Attempt to set the max frames per slice
-    UInt32 maxFPS = 4096;
-    AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS));
-    
-    
-    checkResult(AUGraphUpdate(_audioGraph, NULL), "AUGraphUpdate");
-    
-    checkResult(AudioUnitInitialize(_audioUnit), "AudioUnitInitialize");
-    
-    if ( _inConverterUnit ) {
-        checkResult(AudioUnitInitialize(_inConverterUnit), "AudioUnitInitialize");
-        AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS));
-    }
-    
-    if ( _outConverterUnit ) {
-        checkResult(AudioUnitInitialize(_outConverterUnit), "AudioUnitInitialize");
-        AudioUnitSetProperty(_outConverterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS));
-    }
-    
-    
-    return YES;
-}
-
--(void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:AEAudioControllerDidRecreateGraphNotification object:_audioController];
-    
-    if ( _node ) {
-        checkResult(AUGraphRemoveNode(_audioGraph, _node), "AUGraphRemoveNode");
-    }
-    if ( _outConverterNode ) {
-        checkResult(AUGraphRemoveNode(_audioGraph, _outConverterNode), "AUGraphRemoveNode");
-    }
-    if ( _inConverterNode ) {
-        checkResult(AUGraphRemoveNode(_audioGraph, _inConverterNode), "AUGraphRemoveNode");
-    }
-    
-    checkResult(AUGraphUpdate(_audioGraph, NULL), "AUGraphUpdate");
-    
-    [super dealloc];
-}
-
--(AudioUnit)audioUnit {
-    return _audioUnit;
-}
-
--(AUNode)audioGraphNode {
-    return _node;
-}
-
-static OSStatus filterCallback(id                        filter,
-                               AEAudioController        *audioController,
-                               AEAudioControllerFilterProducer producer,
-                               void                     *producerToken,
-                               const AudioTimeStamp     *time,
-                               UInt32                    frames,
-                               AudioBufferList          *audio) {
-    AEAudioUnitFilter *THIS = (AEAudioUnitFilter*)filter;
-    
-    THIS->_currentProducer = producer;
-    THIS->_currentProducerToken = producerToken;
-    
-    AudioUnitRenderActionFlags flags = 0;
-    checkResult(AudioUnitRender(THIS->_outConverterUnit ? THIS->_outConverterUnit : THIS->_audioUnit, &flags, time, 0, frames, audio), "AudioUnitRender");
-    
-    return noErr;
-}
-
--(AEAudioControllerFilterCallback)filterCallback {
-    return filterCallback;
-}
-
-static OSStatus audioUnitRenderCallback(void                       *inRefCon,
-                                        AudioUnitRenderActionFlags *ioActionFlags,
-                                        const AudioTimeStamp       *inTimeStamp,
-                                        UInt32                      inBusNumber,
-                                        UInt32                      inNumberFrames,
-                                        AudioBufferList            *ioData) {
-    AEAudioUnitFilter *THIS = (AEAudioUnitFilter*)inRefCon;
-    return THIS->_currentProducer(THIS->_currentProducerToken, ioData, &inNumberFrames);
-}
-
-- (void)didRecreateGraph:(NSNotification*)notification {
-    _node = 0;
-    _audioUnit = NULL;
-    _inConverterNode = 0;
-    _inConverterUnit = NULL;
-    _outConverterNode = 0;
-    _outConverterUnit = NULL;
-    _audioGraph = _audioController.audioGraph;
-    [self setup:NULL];
-}
+/*!
+ * The audio graph node
+ */
+@property (nonatomic, readonly) AUNode audioGraphNode;
 
 @end
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Before attempting to set the controller's stream format as the input format of the audio unit, we ask the unit for it's input property. If this is different than the controller's format, we create a converter node. Otherwise, we proceed with attempting to set the controllers format on the node.

This allows something like the 3D mixer unit to behave properly, since although it requires mono input to function correctly, it does not actually complain when a stereo format is applied to its input.
