### PR TITLE
New Init method for AEAudioUnitFilter to allow for default format

### DIFF
--- a/TheAmazingAudioEngine/AEAudioUnitFilter.h
+++ b/TheAmazingAudioEngine/AEAudioUnitFilter.h
@@ -23,9 +23,13 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
 #import <Foundation/Foundation.h>
 #import "TheAmazingAudioEngine.h"
-
+    
 /*!
  * Audio Unit Filter
  *
@@ -49,6 +53,23 @@
                              error:(NSError**)error;
 
 /*!
+ * Create a new Audio Unit filter, using the default input audio description
+ *
+ * @param audioComponentDescription The structure that identifies the audio unit
+ * @param audioController The audio controller
+ * @param useDefaultInputFormat Whether to always use the audio unit's default input audio format.
+ *              This can be used as a workaround for audio units that misidentify the TAAE system
+ *              audio description as being compatible. Audio will automatically be converted from
+ *              the source audio format to this format.
+ * @param error On output, if not NULL, will point to an error if a problem occurred
+ * @return The initialised filter, or nil if an error occurred
+ */
+- (id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
+                   audioController:(AEAudioController*)audioController
+             useDefaultInputFormat:(BOOL)useDefaultInputFormat
+                             error:(NSError**)error;
+
+/*!
  * The audio unit
  */
 @property (nonatomic, readonly) AudioUnit audioUnit;
@@ -59,3 +80,7 @@
 @property (nonatomic, readonly) AUNode audioGraphNode;
 
 @end
+    
+#ifdef __cplusplus
+}
+#endif

--- a/TheAmazingAudioEngine/AEAudioUnitFilter.m
+++ b/TheAmazingAudioEngine/AEAudioUnitFilter.m
@@ -38,6 +38,7 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
 @interface AEAudioUnitFilter () {
     AEAudioController *_audioController;
     AudioComponentDescription _componentDescription;
+    BOOL _useDefaultInputFormat;
     AUNode _node;
     AudioUnit _audioUnit;
     AUNode _inConverterNode;
@@ -55,11 +56,19 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
 - (id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
                    audioController:(AEAudioController*)audioController
                              error:(NSError**)error {
-    if ( !(self = [super init]) ) return nil;
+    return [self initWithComponentDescription:audioComponentDescription audioController:audioController useDefaultInputFormat:NO error:error];
+}
 
+-(id)initWithComponentDescription:(AudioComponentDescription)audioComponentDescription
+                  audioController:(AEAudioController *)audioController
+            useDefaultInputFormat:(BOOL)useDefaultInputFormat
+                            error:(NSError **)error {
+    if ( !(self = [super init]) ) return nil;
+    
     // Create the node, and the audio unit
     _audioController = audioController;
     _componentDescription = audioComponentDescription;
+    _useDefaultInputFormat = useDefaultInputFormat;
     _audioGraph = audioController.audioGraph;
 	
     if ( ![self setup:error] ) {
@@ -87,7 +96,7 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
         // The audio description isn't supported. Assign modified default audio description, and create an audio converter.
         AudioStreamBasicDescription defaultAudioDescription;
         UInt32 size = sizeof(defaultAudioDescription);
-        result = AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, &size);
+        AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, &size);
         defaultAudioDescription.mSampleRate = audioDescription.mSampleRate;
         AEAudioStreamBasicDescriptionSetChannelsPerFrame(&defaultAudioDescription, audioDescription.mChannelsPerFrame);
         if ( !checkResult(result=AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, size), "AudioUnitSetProperty") ) {
@@ -110,14 +119,17 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
     
     // Try to set the input audio description
     audioDescription = _audioController.audioDescription;
-    result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription));
-    if ( result == kAudioUnitErr_FormatNotSupported ) {
+    
+    if ( !_useDefaultInputFormat ) {
+        result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription));
+    }
+    
+    if ( _useDefaultInputFormat || result == kAudioUnitErr_FormatNotSupported ) {
         // The audio description isn't supported. Assign modified default audio description, and create an audio converter.
         AudioStreamBasicDescription defaultAudioDescription;
         UInt32 size = sizeof(defaultAudioDescription);
-        result = AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, &size);
-        defaultAudioDescription.mSampleRate = audioDescription.mSampleRate;
-        AEAudioStreamBasicDescriptionSetChannelsPerFrame(&defaultAudioDescription, audioDescription.mChannelsPerFrame);
+        AudioUnitGetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, &size);
+        
         if ( !checkResult(result=AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &defaultAudioDescription, size), "AudioUnitSetProperty") ) {
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Incompatible audio format" forKey:NSLocalizedDescriptionKey]];
             return NO;
@@ -125,11 +137,7 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
         
         AudioComponentDescription audioConverterDescription = AEAudioComponentDescriptionMake(kAudioUnitManufacturer_Apple, kAudioUnitType_FormatConverter, kAudioUnitSubType_AUConverter);
         
-        if ( !checkResult(result=AUGraphAddNode(_audioGraph, &audioConverterDescription, &_inConverterNode), "AUGraphAddNode") ||
-            !checkResult(result=AUGraphNodeInfo(_audioGraph, _inConverterNode, NULL, &_inConverterUnit), "AUGraphNodeInfo") ||
-            !checkResult(result=AUGraphConnectNodeInput(_audioGraph, _inConverterNode, 0, _node, 0), "AUGraphConnectNodeInput") ||
-            !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ||
-            !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ) {
+        if ( !checkResult(result=AUGraphAddNode(_audioGraph, &audioConverterDescription, &_inConverterNode), "AUGraphAddNode") ||  !checkResult(result=AUGraphNodeInfo(_audioGraph, _inConverterNode, NULL, &_inConverterUnit), "AUGraphNodeInfo") || !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &defaultAudioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") || !checkResult(result=AUGraphConnectNodeInput(_audioGraph, _inConverterNode, 0, _node, 0), "AUGraphConnectNodeInput") || !checkResult(result=AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &audioDescription, sizeof(AudioStreamBasicDescription)), "AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)") ) {
             
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
             return NO;


### PR DESCRIPTION
Incorporated new init method with a useDefaultInputFormat argument, which specifies whether a filter should enforce conversion to its preferred input format. 

Solves an issue with units like the 3D mixer which, for example, requires a mono format but doesn't throw an error if a different format is set on the unit. 

(Reverted my earlier commits to my fork which would have caused conversions to happen more often than would be desired.)
