### PR TITLE
Allowed time stretching filters by keeping per-channel timeStamps.

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -183,7 +183,10 @@ typedef struct __channel_t {
     BOOL             muted;
     AudioStreamBasicDescription audioDescription;
     callback_table_t callbacks;
+    AudioTimeStamp   timeStamp;
+    
     BOOL             setRenderNotification;
+    
     AEAudioController *audioController;
     ABOutputPort    *audiobusOutputPort;
     AEFloatConverter *audiobusFloatConverter;
@@ -437,7 +440,8 @@ static OSStatus channelAudioProducer(void *userInfo, AudioBufferList *audio, UIn
             memset(audio->mBuffers[i].mData, 0, audio->mBuffers[i].mDataByteSize);
         }
         
-        status = callback(channelObj, channel->audioController, &arg->inTimeStamp, *frames, audio);
+        status = callback(channelObj, channel->audioController, &channel->timeStamp, *frames, audio);
+        channel->timeStamp.mSampleTime += *frames;
         
     } else if ( channel->type == kChannelTypeGroup ) {
         AEChannelGroupRef group = (AEChannelGroupRef)channel->ptr;
@@ -449,10 +453,10 @@ static OSStatus channelAudioProducer(void *userInfo, AudioBufferList *audio, UIn
         if ( group->level_monitor_data.monitoringEnabled ) {
             performLevelMonitoring(&group->level_monitor_data, audio, *frames);
         }
-    }
         
-    // Advance the sample time, to make sure we continue to render if we're called again with the same arguments
-    arg->inTimeStamp.mSampleTime += *frames;
+        // Advance the sample time, to make sure we continue to render if we're called again with the same arguments
+        arg->inTimeStamp.mSampleTime += *frames;
+    }
     
     return status;
 }
@@ -466,6 +470,9 @@ static OSStatus renderCallback(void *inRefCon, AudioUnitRenderActionFlags *ioAct
     }
     
     AudioTimeStamp timestamp = *inTimeStamp;
+    if (channel->timeStamp.mFlags == 0) {
+        channel->timeStamp = *inTimeStamp;
+    }
     
     if ( channel->audiobusOutputPort && ABOutputPortGetConnectedPortAttributes(channel->audiobusOutputPort) & ABInputPortAttributePlaysLiveAudio ) {
         // We're sending via the output port, and the receiver plays live - offset the timestamp by the reported latency
@@ -974,6 +981,7 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
         channelElement->pan         = [channel respondsToSelector:@selector(pan)] ? channel.pan : 0.0;
         channelElement->muted       = [channel respondsToSelector:@selector(channelIsMuted)] ? channel.channelIsMuted : NO;
         channelElement->audioDescription = [channel respondsToSelector:@selector(audioDescription)] && channel.audioDescription.mSampleRate ? channel.audioDescription : _audioDescription;
+        memset(&channelElement->timeStamp, 0, sizeof(channelElement->timeStamp));
         channelElement->audioController = self;
         
         group->channels[group->channelCount++] = channelElement;


### PR DESCRIPTION
This fixes #38 - see that issue for a more thorough description. The adds support for using AUVarispeed or AUNewTimePitch audio units (or any custom code that calls `produce` not _exactly_ once per invocation of its own filter callback) to make audio faster or slower.
