### PR TITLE
Make sure all AudioUnits continue rendering during screen lock.

### DIFF
--- a/Modules/AEMixerBuffer.m
+++ b/Modules/AEMixerBuffer.m
@@ -1205,6 +1205,11 @@ static OSStatus sourceInputCallback(void *inRefCon, AudioUnitRenderActionFlags *
     result = AUGraphNodeInfo(_graph, _mixerNode, NULL, &_mixerUnit);
     if ( !checkResult(result, "AUGraphNodeInfo") ) return;
     
+    // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
+    UInt32 maxFPS = 4096;
+    checkResult(AudioUnitSetProperty(_mixerUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
+                "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
+    
     // Try to set mixer's output stream format to our client format
     result = AudioUnitSetProperty(_mixerUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &_clientFormat, sizeof(_clientFormat));
     

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2835,6 +2835,11 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
                             hasFilters = hasReceivers = NO;
                         }
                         
+                        // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
+                        UInt32 maxFPS = 4096;
+                        checkResult(AudioUnitSetProperty(subgroup->converterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
+                                    "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
+                        
                         if ( channel->setRenderNotification ) {
                             checkResult(AudioUnitRemoveRenderNotify(subgroup->mixerAudioUnit, &groupRenderNotifyCallback, channel), "AudioUnitRemoveRenderNotify");
                             channel->setRenderNotification = NO;

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.m
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.m
@@ -118,6 +118,11 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
             return NO;
         }
+        
+        // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
+        UInt32 maxFPS = 4096;
+        checkResult(AudioUnitSetProperty(_converterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
+                    "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
     }
     
     checkResult(AUGraphUpdate(_audioGraph, NULL), "AUGraphUpdate");

--- a/TheAmazingAudioEngine/AEAudioUnitFilter.m
+++ b/TheAmazingAudioEngine/AEAudioUnitFilter.m
@@ -129,6 +129,11 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
             return NO;
         }
+        
+        // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
+        UInt32 maxFPS = 4096;
+        checkResult(AudioUnitSetProperty(_outConverterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
+                    "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
     }
     
     // Try to set the input audio description
@@ -174,6 +179,11 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result userInfo:[NSDictionary dictionaryWithObject:@"Couldn't setup converter audio unit" forKey:NSLocalizedDescriptionKey]];
             return NO;
         }
+        
+        // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
+        UInt32 maxFPS = 4096;
+        checkResult(AudioUnitSetProperty(_inConverterUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
+                    "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
     }
     
     // Set the audio unit's input callback


### PR DESCRIPTION
Some audio units didn't have kAudioUnitProperty_MaximumFramesPerSlice set to 4096, which meant audio would stop playing when the lock button was pressed.
