### PR TITLE
Fixed bug calculating NSTimeInterval to timeStamps that are in the past

### DIFF
--- a/TheAmazingAudioEngine/AEBlockScheduler.m
+++ b/TheAmazingAudioEngine/AEBlockScheduler.m
@@ -65,7 +65,7 @@ struct _schedule_t {
 }
 
 + (NSTimeInterval)secondsUntilTimestamp:(uint64_t)timestamp {
-    return (timestamp - mach_absolute_time()) * __hostTicksToSeconds;
+    return (int64_t)(timestamp - mach_absolute_time()) * __hostTicksToSeconds;
 }
 
 + (uint64_t)timestampWithSeconds:(NSTimeInterval)seconds fromTimestamp:(uint64_t)timeStamp


### PR DESCRIPTION
Time difference is calculated from two uint64_t (unsigned) values. To get correct results when the first value is less than the second value, we have to cast the result to an int64_t (signed) value.
