### PR TITLE
IAA stereo fix

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -511,11 +511,6 @@ typedef void (*AEAudioControllerMainThreadMessageHandler)(AEAudioController *aud
  */
 - (void)stop;
 
-/*!
- * Update input device status
- */
-- (BOOL)updateInputDeviceStatus;
-
 ///@}
 #pragma mark - Channel and channel group management
 /** @name Channel and channel group management */

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2277,6 +2277,11 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
     }
 }
 
+static void IsInterAppConnectedCallback(void *inRefCon, AudioUnit inUnit, AudioUnitPropertyID inID, AudioUnitScope inScope, AudioUnitElement inElement) {
+    AEAudioController *THIS = inRefCon;
+    [THIS updateInputDeviceStatus];
+}
+
 - (void)configureAudioUnit {
     if ( _inputEnabled ) {
         // Enable input
@@ -2322,6 +2327,9 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
     UInt32 maxFPS = 4096;
     checkResult(AudioUnitSetProperty(_ioAudioUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &maxFPS, sizeof(maxFPS)),
                 "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
+
+    checkResult(AudioUnitAddPropertyListener(_ioAudioUnit, kAudioUnitProperty_IsInterAppConnected, IsInterAppConnectedCallback, self),
+                "AudioUnitAddPropertyListener(kAudioUnitProperty_IsInterAppConnected)");
 }
 
 - (void)teardown {


### PR DESCRIPTION
These two commits fixes a bug that would make input mono only when the remoteIO unit is connected to an Inter-App Audio host, since TAAE only looks at available hardware input channels.
