### PR TITLE
Added mixer channel count check to prevent -10877 errors.

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2940,6 +2940,10 @@ NSTimeInterval AEAudioControllerOutputLatency(AEAudioController *controller) {
         
         
         if ( group ) {
+            // Ensure that we have enough input buses in the mixer
+            UInt32 busCount = group->channelCount;
+            checkResult(AudioUnitSetProperty(group->mixerAudioUnit, kAudioUnitProperty_ElementCount, kAudioUnitScope_Input, 0, &busCount, sizeof(busCount)), "AudioUnitSetProperty(kAudioUnitProperty_ElementCount)");
+
             // Set volume
             AudioUnitParameterValue volumeValue = channel->volume;
             checkResult(AudioUnitSetParameter(group->mixerAudioUnit, kMultiChannelMixerParam_Volume, kAudioUnitScope_Input, i, volumeValue, 0),


### PR DESCRIPTION
I was running into similar issues as Pascal was on the forum (see: http://forum.theamazingaudioengine.com/discussion/312/limited-number-of-channels-filters-or-groups-solved/p1) - where `AEAudioController -createChannelGroupWithinChannelGroup:` was causing errors like the following to appear:

```
AEAudioController.m:2905: AudioUnitSetParameter(kMultiChannelMixerParam_Volume) result -10877 FFFFD583 ˇˇ’É
AEAudioController.m:2912: AudioUnitSetParameter(kMultiChannelMixerParam_Pan) result -10877 FFFFD583 ˇˇ’É
AEAudioController.m:2917: AudioUnitSetParameter(kMultiChannelMixerParam_Enable) result -10877 FFFFD583 ˇˇ’É
AEAudioController.m:1137: Update graph result -10877 FFFFD583 ˇˇ’É
```

This PR solves that issue by ensuring the mixer with channels being added to it has enough input busses to handle the new channel.
