### PR TITLE
Fixed group converterNode resource leak.

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -3074,6 +3074,12 @@ static void removeChannelsFromGroup(AEAudioController *THIS, AEChannelGroupRef g
         group->mixerNode = 0;
         group->mixerAudioUnit = NULL;
     }
+
+    if ( group->converterNode ) {
+        checkResult(AUGraphRemoveNode(_audioGraph, group->converterNode), "AUGraphRemoveNode");
+        group->converterNode = 0;
+        group->converterUnit = NULL;
+    }
     
     // Release channel resources too
     for ( int i=0; i<group->channelCount; i++ ) {


### PR DESCRIPTION
When creating `AEChannelGroup`s, `converterNode`s are sometimes created alongside the `mixerNode` for each group. However, in `releaseResourcesForGroup:`, only the mixer node - not the converter node - is removed from the graph, leading to a resource leak if a number of groups are created and destroyed over time.
