### PR TITLE
Fixed limit of 8 sub-channel-groups

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -1136,6 +1136,11 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
     group->channel   = channel;
     
     parentGroup->channelCount++;
+    
+    // Set bus count
+    UInt32 busCount = parentGroup->channelCount;
+    OSStatus result = AudioUnitSetProperty(parentGroup->mixerAudioUnit, kAudioUnitProperty_ElementCount, kAudioUnitScope_Input, 0, &busCount, sizeof(busCount));
+    if ( !checkResult(result, "AudioUnitSetProperty(kAudioUnitProperty_ElementCount)") ) return NULL;
 
     [self configureChannelsInRange:NSMakeRange(groupIndex, 1) forGroup:parentGroup];
     checkResult([self updateGraph], "Update graph");


### PR DESCRIPTION
`createChannelGroupWithinChannelGroup` updates the `parentGroup->channelCount` but never changes the bus count on `parentGroup->mixerAudioUnit`, so no more than 8 subgroups can be successfully created. This PR just sets the `kAudioUnitProperty_ElementCount` to the current channel count whenever a subgroup is created.
