### PR TITLE
Make audio unit channel class more amenable to subclassing

### DIFF
--- a/TheAmazingAudioEngine/AEAudioUnitChannel.h
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.h
@@ -39,6 +39,10 @@ extern "C" {
  *
  */
 @interface AEAudioUnitChannel : NSObject <AEAudioPlayable>
+{
+    AudioUnit _audioUnit;
+    AudioTimeStamp _audioTimeStamp;
+}
 
 /*!
  * Create a new Audio Unit channel

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.m
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.m
@@ -39,7 +39,6 @@ static inline BOOL _checkResult(OSStatus result, const char *operation, const ch
     AEAudioController *_audioController;
     AudioComponentDescription _componentDescription;
     AUNode _node;
-    AudioUnit _audioUnit;
     AUNode _converterNode;
     AudioUnit _converterUnit;
     AUGraph _audioGraph;
@@ -167,6 +166,7 @@ static OSStatus renderCallback(id                        channel,
                                UInt32                    frames,
                                AudioBufferList          *audio) {
     AEAudioUnitChannel *THIS = (AEAudioUnitChannel*)channel;
+    THIS->_audioTimeStamp = *time;
     AudioUnitRenderActionFlags flags = 0;
     checkResult(AudioUnitRender(THIS->_converterUnit ? THIS->_converterUnit : THIS->_audioUnit, &flags, time, 0, frames, audio), "AudioUnitRender");
     return noErr;


### PR DESCRIPTION
Michael, I'd be interested in hearing your thoughts about merging this upstream. 

We found that adding these two protected instance variables to the header allowed us to make more useful subclasses (e.g. a streaming file player with precise timing).

Did you perhaps intend the `preInitializeBlock:` initializer parameter to be a workaround to providing protected access to the audio unit? Seems like that would be somewhat hackier than just exposing it to subclasses.
