### PR TITLE
AEAudioFilePlayer: call alloc init on self in factory method

### DIFF
--- a/TheAmazingAudioEngine/AEAudioFilePlayer.m
+++ b/TheAmazingAudioEngine/AEAudioFilePlayer.m
@@ -47,7 +47,7 @@
 
 + (id)audioFilePlayerWithURL:(NSURL*)url audioController:(AEAudioController *)audioController error:(NSError **)error {
     
-    AEAudioFilePlayer *player = [[[AEAudioFilePlayer alloc] init] autorelease];
+    AEAudioFilePlayer *player = [[[self alloc] init] autorelease];
     player->_volume = 1.0;
     player->_channelIsPlaying = YES;
     player->_audioDescription = audioController.audioDescription;


### PR DESCRIPTION
Currently an object of type `AEAudioFilePlayer` can be returned from the factory method, and this leads to  `unrecognized selector sent to instance` exceptions. 

This commit lets subclasses of `AEAudioFilePlayer` return an object of the subclass's type. 

See: 
http://qualitycoding.org/factory-method/
