### PR TITLE
Use IOBufferDuration instead of preferredBufferDuration to set currentBufferDuration

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -789,7 +789,7 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
         return NO;
     }
     
-    NSTimeInterval bufferDuration = audioSession.preferredIOBufferDuration;
+    NSTimeInterval bufferDuration = audioSession.IOBufferDuration;
     if ( _currentBufferDuration != bufferDuration ) self.currentBufferDuration = bufferDuration;
     
     if ( _inputEnabled ) {


### PR DESCRIPTION
In my usage, I found that there's a short period where the currentBufferDuration is erroneously set to the preferredBufferDuration.

The reason this happens is because -initAudioSession already sets currentBufferDuration to audioSession.IOBufferDuration. After this, if one calls -start, the code in question will see that the preferredBufferDuration doesn't match the already set currentBufferDuration and reset it to the preferred duration. A second later, this goes away, as the housekeeper sets it back again.
