### PR TITLE
Variable name change to satisfy iOS validation.

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController+AudiobusStub.h
+++ b/TheAmazingAudioEngine/AEAudioController+AudiobusStub.h
@@ -47,5 +47,5 @@ typedef void (^ABReceiverPortAudioInputBlock)(ABReceiverPort *receiverPort, UInt
 - (BOOL)connectedToSelf;
 - (void)setAutomaticMonitoring:(BOOL)automaticMonitoring;
 - (AudioUnit)audioUnit;
-- (BOOL)connected;
+- (BOOL)isConnected;
 @end

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2015,7 +2015,7 @@ NSTimeInterval AEAudioControllerOutputLatency(__unsafe_unretained AEAudioControl
     if ( _inputEnabled ) {
         [self updateInputDeviceStatus];
     }
-    if ( [(id<AEAudiobusForwardDeclarationsProtocol>)notification.object connected] && !self.running ) {
+    if ( [(id<AEAudiobusForwardDeclarationsProtocol>)notification.object isConnected] && !self.running ) {
         [self start:NULL];
     }
 }


### PR DESCRIPTION
When attempting to submit an iOS app using TAAE, validation failed with the message:
    "The app references non-public selectors in Payload/****: connected"

This pull request is a simple change to conform with their requirements.