### PR TITLE
AudioBufferList player

### DIFF
--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */; };
 		4CEC0EB916B5294300D11ED9 /* AEBlockFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CEC0EBA16B5294300D11ED9 /* AEBlockFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */; };
+		4D4C4C401A578AF100AA6CB8 /* AEAudioBufferListPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4C4C3E1A578AF100AA6CB8 /* AEAudioBufferListPlayer.h */; };
+		4D4C4C411A578AF100AA6CB8 /* AEAudioBufferListPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C4C3F1A578AF100AA6CB8 /* AEAudioBufferListPlayer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +97,8 @@
 		4CE501971493F82600F23607 /* TheAmazingAudioEngine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TheAmazingAudioEngine-Prefix.pch"; sourceTree = "<group>"; };
 		4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEBlockFilter.h; sourceTree = "<group>"; };
 		4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockFilter.m; sourceTree = "<group>"; };
+		4D4C4C3E1A578AF100AA6CB8 /* AEAudioBufferListPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioBufferListPlayer.h; sourceTree = "<group>"; };
+		4D4C4C3F1A578AF100AA6CB8 /* AEAudioBufferListPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEAudioBufferListPlayer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +180,8 @@
 		4CE501911493F82600F23607 /* TheAmazingAudioEngine */ = {
 			isa = PBXGroup;
 			children = (
+				4D4C4C3E1A578AF100AA6CB8 /* AEAudioBufferListPlayer.h */,
+				4D4C4C3F1A578AF100AA6CB8 /* AEAudioBufferListPlayer.m */,
 				4CAD569315162822003CE861 /* TheAmazingAudioEngine.h */,
 				4CAD56801516281D003CE861 /* AEAudioController.h */,
 				4CAD56811516281D003CE861 /* AEAudioController.m */,
@@ -224,6 +230,7 @@
 				4C49FE32153DC21A008725E0 /* AEAudioFileLoaderOperation.h in Headers */,
 				4C215D141523A94200D36CAD /* AEAudioFilePlayer.h in Headers */,
 				4C38DC5515458AB1009F4454 /* AEAudioFileWriter.h in Headers */,
+				4D4C4C401A578AF100AA6CB8 /* AEAudioBufferListPlayer.h in Headers */,
 				4C215D151523A94200D36CAD /* AEUtilities.h in Headers */,
 				4C8AED0416B3644500958034 /* AEFloatConverter.h in Headers */,
 				4CEC0EB916B5294300D11ED9 /* AEBlockFilter.h in Headers */,
@@ -334,6 +341,7 @@
 				4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */,
 				4C456B8E16D59365008ED99D /* AEBlockAudioReceiver.m in Sources */,
 				4C09450216FBD7460054608E /* AEBlockScheduler.m in Sources */,
+				4D4C4C411A578AF100AA6CB8 /* AEAudioBufferListPlayer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.h
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.h
@@ -1,0 +1,77 @@
+//
+//  AEAudioBufferListPlayer.h
+//  The Amazing Audio Engine
+//
+//  Created by Mark Wise on 01/01/2015.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#import <Foundation/Foundation.h>
+#import "AEAudioController.h"
+
+/*!
+ * Audio file player
+ *
+ *  This class allows you to play audio files, either as one-off samples, or looped.
+ *  It will play any audio file format supported by iOS.
+ *
+ *  To use, create an instance, then add it to the audio controller.
+ */
+@interface AEAudioBufferListPlayer : NSObject <AEAudioPlayable>
+
+/*!
+ * Create a new player instance
+ *
+ * @param audioController   The audio controller
+ * @param error             If not NULL, the error on output
+ * @return The audio player, ready to be @link AEAudioController::addChannels: added @endlink to the audio controller.
+ */
++ (id)audioBufferListPlayerWithAudioController:(AEAudioController*)audioController error:(NSError**)error;
+
+/*!
+ * Create a new player instance with an audio buffer list
+ *
+ * @param audio AudioBufferList to be played
+ * @param audioController   The audio controller
+ * @param error             If not NULL, the error on output
+ * @return The audio player, ready to be @link AEAudioController::addChannels: added @endlink to the audio controller.
+ */
++ (id)audioBufferListPlayerWithAudioBufferList:(AudioBufferList*)audio audioController:(AEAudioController*)audioController error:(NSError**)error;
+
+@property (nonatomic, readwrite) AudioBufferList *audio;   //!< Current playback position, in seconds
+@property (nonatomic, readonly) NSTimeInterval duration;    //!< Length of audio, in seconds
+@property (nonatomic, assign) NSTimeInterval currentTime;   //!< Current playback position, in seconds
+@property (nonatomic, readwrite) BOOL loop;                 //!< Whether to loop this track
+@property (nonatomic, readwrite) float volume;              //!< Track volume
+@property (nonatomic, readwrite) float pan;                 //!< Track pan
+@property (nonatomic, readwrite) BOOL channelIsPlaying;     //!< Whether the track is playing
+@property (nonatomic, readwrite) BOOL channelIsMuted;       //!< Whether the track is muted
+@property (nonatomic, readwrite) BOOL removeUponFinish;     //!< Whether the track automatically removes itself from the audio controller after playback completes
+@property (nonatomic, copy) void(^completionBlock)();       //!< A block to be called when playback finishes
+@property (nonatomic, copy) void(^startLoopBlock)();        //!< A block to be called when the loop restarts in loop mode
+@end
+
+#ifdef __cplusplus
+}
+#endif

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.h
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.h
@@ -31,10 +31,9 @@ extern "C" {
 #import "AEAudioController.h"
 
 /*!
- * Audio file player
+ * AudioBufferList player
  *
- *  This class allows you to play audio files, either as one-off samples, or looped.
- *  It will play any audio file format supported by iOS.
+ *  This class allows you to play audio buffer lists, either as one-off samples, or looped.
  *
  *  To use, create an instance, then add it to the audio controller.
  */
@@ -52,7 +51,7 @@ extern "C" {
 /*!
  * Create a new player instance with an audio buffer list
  *
- * @param audio AudioBufferList to be played
+ * @param audio             The AudioBufferList to be played
  * @param audioController   The audio controller
  * @param error             If not NULL, the error on output
  * @return The audio player, ready to be @link AEAudioController::addChannels: added @endlink to the audio controller.

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
@@ -64,11 +64,13 @@
 -(void)setAudio:(AudioBufferList *)audio {
     _channelIsPlaying = NO;
     _audio = audio;
+
     int *channels = malloc(sizeof(int));;
     _lengthInFrames = AEGetNumberOfFramesInAudioBufferList(audio, _audioDescription, channels);
     _lengthInFrames *= *channels;
-    _duration = (double) _lengthInFrames / (double)_audioDescription.mSampleRate;
     free(channels);
+
+    _duration = (double) _lengthInFrames / (double)_audioDescription.mSampleRate;
 }
 
 -(NSTimeInterval)currentTime {

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
@@ -71,15 +71,6 @@
     free(channels);
 }
 
-- (void)dealloc {
-    if ( _audio ) {
-        for ( int i=0; i<_audio->mNumberBuffers; i++ ) {
-            free(_audio->mBuffers[i].mData);
-        }
-        free(_audio);
-    }
-}
-
 -(NSTimeInterval)currentTime {
     return ((double)_playhead / (double)_lengthInFrames) * _duration;
 }

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
@@ -54,17 +54,9 @@
 }
 
 + (id)audioBufferListPlayerWithAudioBufferList:(AudioBufferList*)audio audioController:(AEAudioController *)audioController error:(NSError **)error {
-    AEAudioBufferListPlayer *player = [[self alloc] init];
-    player->_volume = 1.0;
-    player->_channelIsPlaying = YES;
-    player->_audioDescription = audioController.audioDescription;
-    player->_audio = audio;
+    AEAudioBufferListPlayer *player = [[self alloc] audioBufferListPlayerWithAudioController:audioController error:error];
 
-    int *channels = malloc(sizeof(int));;
-    player->_lengthInFrames = AEGetNumberOfFramesInAudioBufferList(audio, player->_audioDescription, channels);
-    player->_lengthInFrames *= *channels;
-    player->_duration = (double) player->_lengthInFrames / (double)player->_audioDescription.mSampleRate;
-    free(channels);
+    [player setAudio:audio];
 
     return player;
 }

--- a/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
+++ b/TheAmazingAudioEngine/AEAudioBufferListPlayer.m
@@ -1,0 +1,183 @@
+//
+//  AEAudioBufferListPlayer.m
+//  The Amazing Audio Engine
+//
+//  Created by Mark Wise on 01/01/2015.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#import "AEAudioBufferListPlayer.h"
+#import "AEUtilities.h"
+#import <libkern/OSAtomic.h>
+
+#define checkStatus(status) \
+    if ( (status) != noErr ) {\
+        NSLog(@"Error: %ld -> %s:%d", (status), __FILE__, __LINE__);\
+    }
+
+@interface AEAudioBufferListPlayer () {
+    int _lengthInFrames;
+    NSTimeInterval _duration;
+    AudioStreamBasicDescription   _audioDescription;
+    volatile int32_t              _playhead;
+}
+@end
+
+@implementation AEAudioBufferListPlayer
+@synthesize audio=_audio, duration=_duration, loop=_loop, volume=_volume, pan=_pan, channelIsPlaying=_channelIsPlaying, channelIsMuted=_channelIsMuted, removeUponFinish=_removeUponFinish, completionBlock = _completionBlock, startLoopBlock = _startLoopBlock;
+@dynamic currentTime;
+
++ (id)audioBufferListPlayerWithAudioController:(AEAudioController *)audioController error:(NSError **)error {
+    AEAudioBufferListPlayer *player = [[self alloc] init];
+    player->_volume = 1.0;
+    player->_channelIsPlaying = YES;
+    player->_audioDescription = audioController.audioDescription;
+
+    return player;
+}
+
++ (id)audioBufferListPlayerWithAudioBufferList:(AudioBufferList*)audio audioController:(AEAudioController *)audioController error:(NSError **)error {
+    AEAudioBufferListPlayer *player = [[self alloc] init];
+    player->_volume = 1.0;
+    player->_channelIsPlaying = YES;
+    player->_audioDescription = audioController.audioDescription;
+    player->_audio = audio;
+
+    int *channels = malloc(sizeof(int));;
+    player->_lengthInFrames = AEGetNumberOfFramesInAudioBufferList(audio, player->_audioDescription, channels);
+    player->_lengthInFrames *= *channels;
+    player->_duration = (double) player->_lengthInFrames / (double)player->_audioDescription.mSampleRate;
+    free(channels);
+
+    return player;
+}
+
+-(void)setAudio:(AudioBufferList *)audio {
+    _channelIsPlaying = NO;
+    _audio = audio;
+    int *channels = malloc(sizeof(int));;
+    _lengthInFrames = AEGetNumberOfFramesInAudioBufferList(audio, _audioDescription, channels);
+    _lengthInFrames *= *channels;
+    _duration = (double) _lengthInFrames / (double)_audioDescription.mSampleRate;
+    free(channels);
+}
+
+- (void)dealloc {
+    if ( _audio ) {
+        for ( int i=0; i<_audio->mNumberBuffers; i++ ) {
+            free(_audio->mBuffers[i].mData);
+        }
+        free(_audio);
+    }
+}
+
+-(NSTimeInterval)currentTime {
+    return ((double)_playhead / (double)_lengthInFrames) * _duration;
+}
+
+-(void)setCurrentTime:(NSTimeInterval)currentTime {
+    _playhead = (int32_t)((currentTime / [self duration]) * _lengthInFrames) % _lengthInFrames;
+}
+
+static void notifyLoopRestart(AEAudioController *audioController, void *userInfo, int length) {
+    AEAudioBufferListPlayer *THIS = (__bridge AEAudioBufferListPlayer*)*(void**)userInfo;
+
+    if ( THIS.startLoopBlock ) THIS.startLoopBlock();
+}
+
+static void notifyPlaybackStopped(AEAudioController *audioController, void *userInfo, int length) {
+    AEAudioBufferListPlayer *THIS = (__bridge AEAudioBufferListPlayer*)*(void**)userInfo;
+    THIS.channelIsPlaying = NO;
+
+    if ( THIS->_removeUponFinish ) {
+        [audioController removeChannels:@[THIS]];
+    }
+
+    if ( THIS.completionBlock ) THIS.completionBlock();
+
+    THIS->_playhead = 0;
+}
+
+static OSStatus renderCallback(__unsafe_unretained AEAudioBufferListPlayer *THIS, __unsafe_unretained AEAudioController *audioController, const AudioTimeStamp *time, UInt32 frames, AudioBufferList *audio) {
+    int32_t playhead = THIS->_playhead;
+    int32_t originalPlayhead = playhead;
+
+    if ( !THIS->_channelIsPlaying ) return noErr;
+
+    if ( !THIS->_loop && playhead == THIS->_lengthInFrames ) {
+        // Notify main thread that playback has finished
+        AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyPlaybackStopped, &THIS, sizeof(AEAudioBufferListPlayer*));
+        THIS->_channelIsPlaying = NO;
+        return noErr;
+    }
+
+    // Get pointers to each buffer that we can advance
+    char *audioPtrs[audio->mNumberBuffers];
+    for ( int i=0; i<audio->mNumberBuffers; i++ ) {
+        audioPtrs[i] = audio->mBuffers[i].mData;
+    }
+
+    int bytesPerFrame = THIS->_audioDescription.mBytesPerFrame;
+    int remainingFrames = frames;
+
+    // Copy audio in contiguous chunks, wrapping around if we're looping
+    while ( remainingFrames > 0 ) {
+        // The number of frames left before the end of the audio
+        int framesToCopy = MIN(remainingFrames, THIS->_lengthInFrames - playhead);
+
+        // Fill each buffer with the audio
+        for ( int i=0; i<audio->mNumberBuffers; i++ ) {
+            memcpy(audioPtrs[i], ((char*)THIS->_audio->mBuffers[i].mData) + playhead * bytesPerFrame, framesToCopy * bytesPerFrame);
+
+            // Advance the output buffers
+            audioPtrs[i] += framesToCopy * bytesPerFrame;
+        }
+
+        // Advance playhead
+        remainingFrames -= framesToCopy;
+        playhead += framesToCopy;
+
+        if ( playhead >= THIS->_lengthInFrames ) {
+            // Reached the end of the audio - either loop, or stop
+            if ( THIS->_loop ) {
+                playhead = 0;
+                if ( THIS->_startLoopBlock ) {
+                    // Notify main thread that the loop playback has restarted
+                    AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyLoopRestart, &THIS, sizeof(AEAudioBufferListPlayer*));
+                }
+            } else {
+                // Notify main thread that playback has finished
+                AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyPlaybackStopped, &THIS, sizeof(AEAudioBufferListPlayer*));
+                THIS->_channelIsPlaying = NO;
+                break;
+            }
+        }
+    }
+
+    OSAtomicCompareAndSwap32(originalPlayhead, playhead, &THIS->_playhead);
+
+    return noErr;
+}
+
+-(AEAudioControllerRenderCallback)renderCallback {
+    return &renderCallback;
+}
+
+@end


### PR DESCRIPTION
This PR adds a AEAudioBufferListPlayer class that implements AEAudioPlayable. I needed this functionality and saw a few mentions of it in the forums.

It's got a *lot* of code in common with the AEAudioFilePlayer, so perhaps they could both be refactored to extract these shared parts. To keep this PR simple, I didn't touch the AEAudioFilePlayer class.

I whipped this up after playing around with the new AVAudioPlayerNode class in the AVFoundation framework, which handles playing files, file segments, and buffers (including scheduled playback in the future). If you'd prefer a single implementation for a AEAudioPlayer class or similar, I can take a stab at that. Given the common code mentioned above, that approach might make sense.

Please take a look and let me know if anything needs changing. I updated the copyright on these two source files. Feel free to update that as needed - I wasn't sure of the protocol on that.