### PR TITLE
add AEFadeFilter module

### DIFF
--- a/Modules/AEFadeFilter.h
+++ b/Modules/AEFadeFilter.h
@@ -1,0 +1,84 @@
+//
+//  AEFadeFilter.h
+//  TheAmazingAudioEngine
+//
+//  Created by Mark Wise on 01/01/2015.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+//
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#import <Foundation/Foundation.h>
+#import "AEAudioController.h"
+#import "AEBlockFilter.h"
+
+@protocol AEFadeFilterDelegate;
+
+@interface AEFadeFilter : AEBlockFilter <AEAudioFilter>
+
+/*!
+ * Create a new fade filter instance
+ *
+ * This class allows you to fade audio in or out over a specified duration.
+ * It is a subclass of AEBlockFilter. To use it, create an instance of the
+ * filter and then add it with @link AEAudioController::addFilter: @endlink
+ * , @link AEAudioController::addFilter:toChannel: @endlink or
+ * @link AEAudioController::addFilter:toChannel: @endlink.
+ *
+ * To start a fade in (or out), send the filter a @link startFadeOut:milliseconds @endlink
+ * or @link startFadeIn:milliseconds * @endlink message.
+ *
+ * @param audioController     The AEAudioController instance
+ * @return The fade filter instance
+ */
++ (AEBlockFilter*)initWithAudioController:(AEAudioController*)audioController;
+- (void)startFadeOut:(int)milliseconds;
+- (void)startFadeIn:(int)milliseconds;
+
+/*!
+ * Delegate object
+ *
+ * Will be notified when fades are complete
+ */
+@property (nonatomic, weak) id<AEFadeFilterDelegate> delegate;
+
+
+/*!
+ * The AEAudioController instance
+ */
+@property (nonatomic, assign) AEAudioController *audioController;
+
+@end
+
+@protocol AEFadeFilterDelegate <NSObject>
+
+@optional
+-(void)onFadeInComplete;
+-(void)onFadeOutComplete;
+
+@end
+
+#ifdef __cplusplus
+}
+#endif

--- a/Modules/AEFadeFilter.h
+++ b/Modules/AEFadeFilter.h
@@ -22,7 +22,6 @@
 //
 //  3. This notice may not be removed or altered from any source distribution.
 //
-//
 
 #ifdef __cplusplus
 extern "C" {

--- a/Modules/AEFadeFilter.h
+++ b/Modules/AEFadeFilter.h
@@ -28,17 +28,14 @@
 extern "C" {
 #endif
 
-
 #import <Foundation/Foundation.h>
 #import "AEAudioController.h"
 #import "AEBlockFilter.h"
 
 @protocol AEFadeFilterDelegate;
 
-@interface AEFadeFilter : AEBlockFilter <AEAudioFilter>
-
 /*!
- * Create a new fade filter instance
+ * Audio fade filter class
  *
  * This class allows you to fade audio in or out over a specified duration.
  * It is a subclass of AEBlockFilter. To use it, create an instance of the
@@ -46,15 +43,36 @@ extern "C" {
  * , @link AEAudioController::addFilter:toChannel: @endlink or
  * @link AEAudioController::addFilter:toChannel: @endlink.
  *
- * To start a fade in (or out), send the filter a @link startFadeOut:milliseconds @endlink
- * or @link startFadeIn:milliseconds * @endlink message.
+ */
+@interface AEFadeFilter : AEBlockFilter <AEAudioFilter>
+
+/*!
+ * Create a new fade filter instance
  *
  * @param audioController     The AEAudioController instance
  * @return The fade filter instance
  */
 + (AEBlockFilter*)initWithAudioController:(AEAudioController*)audioController;
-- (void)startFadeOut:(int)milliseconds;
+
+
+/*!
+ * Begin fade in
+ *
+ *  Start fading audio from the instance's current adjustment level to full
+ *  volume.
+ *
+ * @param milliseconds    The duration of the fade
+ */
 - (void)startFadeIn:(int)milliseconds;
+
+/*!
+ * Begin fade in
+ *
+ *  Start fading audio from the instance's current adjustment level to silience.
+ *
+ * @param milliseconds    The duration of the fade
+ */
+- (void)startFadeOut:(int)milliseconds;
 
 /*!
  * Delegate object
@@ -63,7 +81,6 @@ extern "C" {
  */
 @property (nonatomic, weak) id<AEFadeFilterDelegate> delegate;
 
-
 /*!
  * The AEAudioController instance
  */
@@ -71,10 +88,33 @@ extern "C" {
 
 @end
 
+/*!
+ * Fade filter delegate protocol
+ *
+ * Implements methods to receive notifications when an AEFadeFilter has
+ * completed fading audio in or out.
+ *
+ */
 @protocol AEFadeFilterDelegate <NSObject>
 
 @optional
+
+/*!
+ * Fade in completion handler
+ *
+ * If specified, this selector will be performed on the delegate when a fade in
+ * has completed.
+ *
+ */
 -(void)onFadeInComplete;
+
+/*!
+ * Fade out completion handler
+ *
+ * If specified, this selector will be performed on the delegate when a fade out
+ * has completed.
+ *
+ */
 -(void)onFadeOutComplete;
 
 @end

--- a/Modules/AEFadeFilter.m
+++ b/Modules/AEFadeFilter.m
@@ -165,19 +165,20 @@ static float const maxReduction = 60.0;
     return;
 }
 
-- (void)startFadeOut:(int)milliseconds {
-    _isFading = NO;
-    [self prepareDbGainTable:milliseconds toRatio: 0.0];
-    _sampleGainStep = 0;
-    _fadeDirection = kAEFadeFilterFadeOut;
-    _isFading = YES;
-}
-
 - (void)startFadeIn:(int)milliseconds {
     _isFading = NO;
     [self prepareDbGainTable:milliseconds toRatio: 1.0];
     _sampleGainStep = 0;
     _fadeDirection = kAEFadeFilterFadeIn;
+    _isFading = YES;
+}
+
+
+- (void)startFadeOut:(int)milliseconds {
+    _isFading = NO;
+    [self prepareDbGainTable:milliseconds toRatio: 0.0];
+    _sampleGainStep = 0;
+    _fadeDirection = kAEFadeFilterFadeOut;
     _isFading = YES;
 }
 
@@ -203,6 +204,5 @@ static float floatToDecibel(float value) {
         return maxReduction * -1.0;
     }
 }
-
 
 @end

--- a/Modules/AEFadeFilter.m
+++ b/Modules/AEFadeFilter.m
@@ -22,7 +22,6 @@
 //
 //  3. This notice may not be removed or altered from any source distribution.
 //
-//
 
 #import "AEFadeFilter.h"
 

--- a/Modules/AEFadeFilter.m
+++ b/Modules/AEFadeFilter.m
@@ -1,0 +1,208 @@
+//
+//  AEFadeFilter.h
+//  TheAmazingAudioEngine
+//
+//  Created by Mark Wise on 01/01/2015.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+//
+
+#import "AEFadeFilter.h"
+
+#define kAEFadeFilterFadeIn (0)
+#define kAEFadeFilterFadeOut (1)
+
+@interface AEFadeFilter (){
+    AEBlockFilterBlock block;
+    float* _sampleGainRatios;
+    bool _isFading;
+    int _fadeDirection;
+    int _sampleGainStep;
+    int _envelopeNumSamples;
+    float _currentGainRatio;
+    float _destinationGainRatio;
+    AudioStreamBasicDescription asbd;
+    UInt32 bytesPerChannel;
+}
+@end
+
+static float floatToDecibel(float value);
+static float const maxReduction = 60.0;
+
+@implementation AEFadeFilter
+
++ (AEFadeFilter*)initWithAudioController:(AEAudioController*)inAudioController {
+    return [[AEFadeFilter alloc] initWithAudioController:inAudioController];
+}
+
+- (id)initWithAudioController:(AEAudioController*)audioController {
+    AEFadeFilter * __weak weakSelf = self;
+
+    self = [self initWithBlock:^(AEAudioControllerFilterProducer producer,
+                                              void                     *producerToken,
+                                              const AudioTimeStamp     *time,
+                                              UInt32                    frames,
+                                              AudioBufferList          *audio) {
+      // Pull audio
+      OSStatus status = producer(producerToken, audio, &frames);
+      if ( status != noErr ) return;
+
+      for (int bufCount=0; bufCount < audio->mNumberBuffers; bufCount++) {
+          AudioBuffer buf = audio->mBuffers[bufCount];
+          [self processBuffer:buf frames:frames step:_sampleGainStep];
+      }
+
+      if (_isFading) {
+          _sampleGainStep += (int) frames;
+          if (_sampleGainStep > _envelopeNumSamples - 1) {
+              if (weakSelf.delegate) {
+                  if (_fadeDirection == kAEFadeFilterFadeOut && [weakSelf.delegate respondsToSelector:@selector(onFadeOutComplete)]) {
+                      [weakSelf.delegate onFadeOutComplete];
+                  }
+                  if (_fadeDirection == kAEFadeFilterFadeIn && [weakSelf.delegate respondsToSelector:@selector(onFadeInComplete)]) {
+                      [weakSelf.delegate onFadeInComplete];
+                  }
+              }
+              if (_destinationGainRatio != -1) {
+                  _currentGainRatio = _destinationGainRatio;
+                  _destinationGainRatio = -1;
+              }
+              _isFading = NO;
+          }
+      }
+    } audioController: audioController];
+
+    return self;
+}
+
+- (id)initWithBlock:(AEBlockFilterBlock)inBlock audioController:(AEAudioController *)inAudioController{
+    if ( !(self = [super init]) ) self = nil;
+
+    block = inBlock;
+    _audioController = inAudioController;
+    asbd = _audioController.audioDescription;
+    bytesPerChannel = asbd.mBytesPerFrame / asbd.mChannelsPerFrame;
+
+    _currentGainRatio = 0.0;
+    _isFading = NO;
+
+    return self;
+}
+
+- (void)processBuffer:(AudioBuffer)buf frames:(UInt32)frames step:(int)step {
+    float sample = 0;
+    int currentFrame = 0;
+
+    while ( currentFrame < frames ) {
+        for (int currentChannel=0; currentChannel < buf.mNumberChannels; currentChannel++) {
+            memcpy(&sample,
+                buf.mData +
+                  (currentFrame * asbd.mBytesPerFrame) +
+                  (currentChannel * bytesPerChannel),
+                sizeof(float));
+
+            if (_isFading && step < (_envelopeNumSamples - 1) ) {
+                _currentGainRatio = _sampleGainRatios[step];
+            }
+            sample = _currentGainRatio * sample;
+
+            memcpy(buf.mData +
+                (currentFrame * asbd.mBytesPerFrame) +
+                (currentChannel * bytesPerChannel),
+                &sample,
+                sizeof(float));
+        }
+        step++;
+        currentFrame++;
+    }
+}
+
+- (void)freeDbGainTable {
+    if (_sampleGainRatios) {
+        free(_sampleGainRatios);
+    }
+}
+
+- (void)prepareDbGainTable:(int)milliseconds toRatio:(float)_toRatio {
+    [self freeDbGainTable];
+
+    float sampleRate = _audioController.audioDescription.mSampleRate;
+    float fadeTimeSeconds = (float) milliseconds / 1000.0;
+
+    _envelopeNumSamples = (int) sampleRate * fadeTimeSeconds;
+    _sampleGainRatios = (float*) malloc(sizeof(float) * _envelopeNumSamples);
+    _destinationGainRatio = _toRatio;
+
+    float currentDb = floatToDecibel(_currentGainRatio);
+    float deltaDb = floatToDecibel(_toRatio) - currentDb;
+    float dbPerStep = deltaDb / _envelopeNumSamples;
+
+    float db, gainRatio;
+
+    for (int step = 0; step < _envelopeNumSamples; step++) {
+        db = step * dbPerStep;
+        gainRatio = pow(10.0, (currentDb + db) / 20.0);
+        _sampleGainRatios[step] = gainRatio;
+    }
+
+    return;
+}
+
+- (void)startFadeOut:(int)milliseconds {
+    _isFading = NO;
+    [self prepareDbGainTable:milliseconds toRatio: 0.0];
+    _sampleGainStep = 0;
+    _fadeDirection = kAEFadeFilterFadeOut;
+    _isFading = YES;
+}
+
+- (void)startFadeIn:(int)milliseconds {
+    _isFading = NO;
+    [self prepareDbGainTable:milliseconds toRatio: 1.0];
+    _sampleGainStep = 0;
+    _fadeDirection = kAEFadeFilterFadeIn;
+    _isFading = YES;
+}
+
+static OSStatus filterCallback(__unsafe_unretained AEFadeFilter *THIS,
+                               __unsafe_unretained AEAudioController *audioController,
+                               AEAudioControllerFilterProducer producer,
+                               void                     *producerToken,
+                               const AudioTimeStamp     *time,
+                               UInt32                    frames,
+                               AudioBufferList          *audio) {
+    THIS->block(producer, producerToken, time, frames, audio);
+    return noErr;
+}
+
+- (AEAudioControllerFilterCallback)filterCallback {
+    return filterCallback;
+}
+
+static float floatToDecibel(float value) {
+    if (value > 0.001) {
+        return 20 * log10(value);
+    } else {
+        return maxReduction * -1.0;
+    }
+}
+
+
+@end

--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */; };
 		4CEC0EB916B5294300D11ED9 /* AEBlockFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CEC0EBA16B5294300D11ED9 /* AEBlockFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */; };
+		4D4C4C441A57A1FF00AA6CB8 /* AEFadeFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4C4C421A57A1FF00AA6CB8 /* AEFadeFilter.h */; };
+		4D4C4C451A57A1FF00AA6CB8 /* AEFadeFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C4C431A57A1FF00AA6CB8 /* AEFadeFilter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +97,8 @@
 		4CE501971493F82600F23607 /* TheAmazingAudioEngine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TheAmazingAudioEngine-Prefix.pch"; sourceTree = "<group>"; };
 		4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEBlockFilter.h; sourceTree = "<group>"; };
 		4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockFilter.m; sourceTree = "<group>"; };
+		4D4C4C421A57A1FF00AA6CB8 /* AEFadeFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AEFadeFilter.h; path = Modules/AEFadeFilter.h; sourceTree = "<group>"; };
+		4D4C4C431A57A1FF00AA6CB8 /* AEFadeFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AEFadeFilter.m; path = Modules/AEFadeFilter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +142,8 @@
 		4C8A0F401540BBD700307CB6 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				4D4C4C421A57A1FF00AA6CB8 /* AEFadeFilter.h */,
+				4D4C4C431A57A1FF00AA6CB8 /* AEFadeFilter.m */,
 				4C698CF7162B02EF008B159D /* TPCircularBuffer */,
 				4C8A0F3D1540BBD300307CB6 /* AEMixerBuffer.h */,
 				4C8A0F3E1540BBD300307CB6 /* AEMixerBuffer.m */,
@@ -220,6 +226,7 @@
 			files = (
 				4C215D121523A94200D36CAD /* TheAmazingAudioEngine.h in Headers */,
 				4C2886381556FC620074175A /* AEAudioController+Audiobus.h in Headers */,
+				4D4C4C441A57A1FF00AA6CB8 /* AEFadeFilter.h in Headers */,
 				4C215D131523A94200D36CAD /* AEAudioController.h in Headers */,
 				4C49FE32153DC21A008725E0 /* AEAudioFileLoaderOperation.h in Headers */,
 				4C215D141523A94200D36CAD /* AEAudioFilePlayer.h in Headers */,
@@ -324,6 +331,7 @@
 				4C215D0A1523A8E500D36CAD /* AEUtilities.c in Sources */,
 				4C49FE34153DC21A008725E0 /* AEAudioFileLoaderOperation.m in Sources */,
 				4C38DC5715458AB1009F4454 /* AEAudioFileWriter.m in Sources */,
+				4D4C4C451A57A1FF00AA6CB8 /* AEFadeFilter.m in Sources */,
 				4C2886521557DB800074175A /* AEAudioController+Audiobus.m in Sources */,
 				4C25747415F0D8E100D232E8 /* TPCircularBuffer.c in Sources */,
 				4C698CFD162B02EF008B159D /* TPCircularBuffer+AudioBufferList.c in Sources */,


### PR DESCRIPTION
This PR adds an `AEFadeFilter` module, an AEBlockFilter subclass that performs simple audio fades on the filtered signal. When a fade in/out is requested for a given duration (in milliseconds), the filter builds a lookup table of gain ratios and multiplies each sample of the input stream accordingly. It supports a delegate object; if specified, this delegate will receive `onFadeInComplete` and `onFadeOutComplete` messages upon completion of the fade.

I'm not sure if this module is within the scope of TheAmazingAudioEngine, but I have found it to be quite useful for fading audio signals smoothly in situations where other automation means are not available.

Also, the initializer code is admittedly a bit hairy - this was my initial experience with retaining a weak reference to self. Suggestions on a cleaner approach would be welcome. 

I've added comments-as-documentation and tried to adhere to the style of the rest of TAAE. I ported this code from a different Obj-C style, so there may be a few lingering style issues. Apologies in advance for anything dumb.

Please take a look and let me know if this is something that belongs in TAAE or if there are any changes I need to make.

Cheers,

Mark