### PR TITLE
Fix for AERecorder using ARC

### DIFF
--- a/Modules/AERecorder.m
+++ b/Modules/AERecorder.m
@@ -61,7 +61,6 @@ NSString * kAERecorderErrorKey = @"error";
 
 -(void)dealloc {
     free(_buffer);
-    [super dealloc];
 }
 
 
@@ -115,7 +114,7 @@ void AERecorderStopRecording(__unsafe_unretained AERecorder* THIS) {
 struct reportError_t { void *THIS; OSStatus result; };
 static void reportError(AEAudioController *audioController, void *userInfo, int length) {
     struct reportError_t *arg = userInfo;
-    [((AERecorder*)arg->THIS) finishRecording];
+    [((__bridge AERecorder*)arg->THIS) finishRecording];
     NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain 
                                          code:arg->result
                                      userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Error while saving audio: Code %d", @""), arg->result]}];


### PR DESCRIPTION
just removed a [super dealloc] and added a bridge cast to fix the class for ARC compiling