### PR TITLE
set TPCircularBuffer as cocoapod dependency to play nice with others

### DIFF
--- a/Modules/AELimiter.m
+++ b/Modules/AELimiter.m
@@ -25,8 +25,13 @@
 
 #import "AELimiter.h"
 #import "TheAmazingAudioEngine.h"
+#if COCOAPODS
+#import <TPCircularBuffer.h>
+#import <TPCircularBuffer+AudioBufferList.h>
+#else
 #import "TPCircularBuffer.h"
 #import "TPCircularBuffer+AudioBufferList.h"
+#endif
 #import <Accelerate/Accelerate.h>
 
 const int kBufferSize = 88200; /* Bytes per channel */

--- a/Modules/AEMixerBuffer.m
+++ b/Modules/AEMixerBuffer.m
@@ -24,8 +24,13 @@
 //
 
 #import "AEMixerBuffer.h"
+#if COCOAPODS
+#import <TPCircularBuffer.h>
+#import <TPCircularBuffer+AudioBufferList.h>
+#else
 #import "TPCircularBuffer.h"
 #import "TPCircularBuffer+AudioBufferList.h"
+#endif
 #import "AEFloatConverter.h"
 #import "AEUtilities.h"
 #import <libkern/OSAtomic.h>

--- a/Modules/TPCircularBuffer/TPCircularBuffer+AudioBufferList.h
+++ b/Modules/TPCircularBuffer/TPCircularBuffer+AudioBufferList.h
@@ -34,7 +34,11 @@
 extern "C" {
 #endif
 
+#if COCOAPODS
+#include <TPCircularBuffer/TPCircularBuffer.h>
+#else
 #include "TPCircularBuffer.h"
+#endif    
 #include <AudioToolbox/AudioToolbox.h>
 
 #define kTPCircularBufferCopyAll UINT32_MAX

--- a/Modules/TPCircularBuffer/TPCircularBuffer.c
+++ b/Modules/TPCircularBuffer/TPCircularBuffer.c
@@ -27,7 +27,11 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
+#if COCOAPODS
+#include <TPCircularBuffer/TPCircularBuffer.h>
+#else
 #include "TPCircularBuffer.h"
+#endif
 #include <mach/mach.h>
 #include <stdio.h>
 

--- a/TheAmazingAudioEngine.podspec
+++ b/TheAmazingAudioEngine.podspec
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '6.0'
   s.source_files = 'TheAmazingAudioEngine/**/*.{h,m,c}', 'Modules/*.{h,m,c}'
   s.frameworks = 'AudioToolbox', 'Accelerate'
+  s.dependency 'TPCircularBuffer', '~> 0.0'
   s.requires_arc = true
 end

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -28,7 +28,11 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 #import <libkern/OSAtomic.h>
+#if COCOAPODS
+#import <TPCircularBuffer.h>
+#else
 #import "TPCircularBuffer.h"
+#endif
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #import <Accelerate/Accelerate.h>

--- a/TheAmazingAudioEngine/Library/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
+++ b/TheAmazingAudioEngine/Library/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
@@ -27,7 +27,11 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
+#if COCOAPODS
+#include <TPCircularBuffer+AudioBufferList.h>
+#else
 #include "TPCircularBuffer+AudioBufferList.h"
+#endif
 #import <mach/mach_time.h>
 
 static double __secondsToHostTicks = 0.0;

--- a/TheAmazingAudioEngine/Library/TPCircularBuffer/TPCircularBuffer.c
+++ b/TheAmazingAudioEngine/Library/TPCircularBuffer/TPCircularBuffer.c
@@ -27,7 +27,11 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
+#if COCOAPODS
+#include <TPCircularBuffer.h>
+#else
 #include "TPCircularBuffer.h"
+#endif
 #include <mach/mach.h>
 #include <stdio.h>
 


### PR DESCRIPTION
If you use AmazingAudio together with other cocoapods that use TPCircularBuffer, you'll get linker errors due to duplicate symbols. The way to solve this is to depend on the TPCircularBuffer cocoapod if the user uses the AmazingAudio cocoapod.