### PR TITLE
Add compatibility for OS X audio output

### DIFF
--- a/TheAmazingAudioEngine.podspec
+++ b/TheAmazingAudioEngine.podspec
@@ -6,7 +6,8 @@ Pod::Spec.new do |s|
   s.license      = 'zlib'
   s.author       = { "Michael Tyson" => "michael@atastypixel.com" }
   s.source       = { :git => "https://github.com/TheAmazingAudioEngine/TheAmazingAudioEngine.git", :tag => "1.4.7" }
-  s.platform     = :ios, '6.0'
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.9'
   s.source_files = 'TheAmazingAudioEngine/**/*.{h,m,c}', 'Modules/*.{h,m,c}'
   s.compiler_flags = '-DTPCircularBuffer=TAAEBuffer',
 					'-DTPCircularBufferInit=TAAEBufferInit',

--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -37,6 +37,36 @@
 		4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */; };
 		4CEC0EB916B5294300D11ED9 /* AEBlockFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CEC0EBA16B5294300D11ED9 /* AEBlockFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */; };
+		7A5687141B54617200243427 /* AEAudioController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CAD56811516281D003CE861 /* AEAudioController.m */; };
+		7A5687151B54617200243427 /* AEAudioController+Audiobus.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2886511557DB800074175A /* AEAudioController+Audiobus.m */; };
+		7A5687161B54617200243427 /* AEAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CAD56AA15163488003CE861 /* AEAudioFilePlayer.m */; };
+		7A5687171B54617200243427 /* AEAudioFileWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C38DC5415458AB1009F4454 /* AEAudioFileWriter.m */; };
+		7A5687181B54617200243427 /* AEUtilities.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C12CC99151D1EDA00562E2A /* AEUtilities.c */; };
+		7A5687191B54617200243427 /* AEBlockChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B11F316833FDD00A3BA2E /* AEBlockChannel.m */; };
+		7A56871A1B54617200243427 /* AEAudioUnitFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */; };
+		7A56871B1B54617200243427 /* AEAudioUnitChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588416BB74720011FB01 /* AEAudioUnitChannel.m */; };
+		7A56871C1B54617200243427 /* AEBlockFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */; };
+		7A56871D1B54617200243427 /* AEBlockAudioReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C456B8C16D59365008ED99D /* AEBlockAudioReceiver.m */; };
+		7A56871E1B54617200243427 /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C8AED0316B3644500958034 /* AEFloatConverter.m */; };
+		7A56871F1B54617200243427 /* AEAudioFileLoaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C49FE31153DC21A008725E0 /* AEAudioFileLoaderOperation.m */; };
+		7A5687201B54617200243427 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C25747215F0D8E000D232E8 /* TPCircularBuffer.c */; };
+		7A5687211B54617200243427 /* AEBlockScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C09450016FBD7460054608E /* AEBlockScheduler.m */; };
+		7A5687221B54618B00243427 /* TPCircularBuffer+AudioBufferList.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C698CF9162B02EF008B159D /* TPCircularBuffer+AudioBufferList.c */; };
+		7A5687241B5461A000243427 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A5687231B5461A000243427 /* Foundation.framework */; };
+		7A5687251B5461BE00243427 /* TheAmazingAudioEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CAD569315162822003CE861 /* TheAmazingAudioEngine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687261B5461BE00243427 /* AEAudioController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CAD56801516281D003CE861 /* AEAudioController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687271B5461BE00243427 /* AEAudioController+Audiobus.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2886361556FC620074175A /* AEAudioController+Audiobus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687291B5461BE00243427 /* AEAudioFilePlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CAD56A915163488003CE861 /* AEAudioFilePlayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872A1B5461BE00243427 /* AEAudioFileWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C38DC5315458AB1009F4454 /* AEAudioFileWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872B1B5461BE00243427 /* AEUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C12CC98151D1EDA00562E2A /* AEUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872C1B5461BE00243427 /* AEBlockChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C4B11F216833FDD00A3BA2E /* AEBlockChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872D1B5461BE00243427 /* AEAudioUnitFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C99588B16C0825E0011FB01 /* AEAudioUnitFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872E1B5461BE00243427 /* AEAudioUnitChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C99588316BB74720011FB01 /* AEAudioUnitChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A56872F1B5461BE00243427 /* AEBlockFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687301B5461BE00243427 /* AEBlockAudioReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C456B8B16D59365008ED99D /* AEBlockAudioReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687311B5461BE00243427 /* AEFloatConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8AED0216B3644500958034 /* AEFloatConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687321B5461BE00243427 /* AEAudioFileLoaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C49FE30153DC21A008725E0 /* AEAudioFileLoaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A5687341B5461BE00243427 /* AEBlockScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0944FF16FBD7460054608E /* AEBlockScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,7 +74,7 @@
 		4C09450016FBD7460054608E /* AEBlockScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockScheduler.m; sourceTree = "<group>"; };
 		4C12CC98151D1EDA00562E2A /* AEUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEUtilities.h; sourceTree = "<group>"; };
 		4C12CC99151D1EDA00562E2A /* AEUtilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = AEUtilities.c; sourceTree = "<group>"; };
-		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTheAmazingAudioEngine.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libTheAmazingAudioEngine.a; path = "libTheAmazingAudioEngine iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C215CEE1523A7D500D36CAD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4C23241F15AC5E2600038EC0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4C23242215AC5E2600038EC0 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -95,6 +125,8 @@
 		4CE501971493F82600F23607 /* TheAmazingAudioEngine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TheAmazingAudioEngine-Prefix.pch"; sourceTree = "<group>"; };
 		4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEBlockFilter.h; sourceTree = "<group>"; };
 		4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockFilter.m; sourceTree = "<group>"; };
+		7A5687101B54610900243427 /* libTheAmazingAudioEngine OS X.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libTheAmazingAudioEngine OS X.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A5687231B5461A000243427 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		B0EE36FC1AD4270400D7AB17 /* AESequencerBeat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerBeat.h; sourceTree = "<group>"; };
 		B0EE36FD1AD4270400D7AB17 /* AESequencerBeat.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AESequencerBeat.m; sourceTree = "<group>"; };
 		B0EE36FE1AD4270400D7AB17 /* AESequencerChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerChannel.h; sourceTree = "<group>"; };
@@ -112,12 +144,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7A56870D1B54610900243427 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A5687241B5461A000243427 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		4C215CED1523A7D500D36CAD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7A5687231B5461A000243427 /* Foundation.framework */,
 				4C23245915AC5FE800038EC0 /* QuartzCore.framework */,
 				4C23245515AC5FDA00038EC0 /* Accelerate.framework */,
 				4C23245615AC5FDA00038EC0 /* AudioToolbox.framework */,
@@ -176,6 +217,7 @@
 			isa = PBXGroup;
 			children = (
 				4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */,
+				7A5687101B54610900243427 /* libTheAmazingAudioEngine OS X.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +298,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7A56870E1B54610900243427 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A5687251B5461BE00243427 /* TheAmazingAudioEngine.h in Headers */,
+				7A5687261B5461BE00243427 /* AEAudioController.h in Headers */,
+				7A5687271B5461BE00243427 /* AEAudioController+Audiobus.h in Headers */,
+				7A5687291B5461BE00243427 /* AEAudioFilePlayer.h in Headers */,
+				7A56872A1B5461BE00243427 /* AEAudioFileWriter.h in Headers */,
+				7A56872B1B5461BE00243427 /* AEUtilities.h in Headers */,
+				7A56872C1B5461BE00243427 /* AEBlockChannel.h in Headers */,
+				7A56872D1B5461BE00243427 /* AEAudioUnitFilter.h in Headers */,
+				7A56872E1B5461BE00243427 /* AEAudioUnitChannel.h in Headers */,
+				7A56872F1B5461BE00243427 /* AEBlockFilter.h in Headers */,
+				7A5687301B5461BE00243427 /* AEBlockAudioReceiver.h in Headers */,
+				7A5687311B5461BE00243427 /* AEFloatConverter.h in Headers */,
+				7A5687321B5461BE00243427 /* AEAudioFileLoaderOperation.h in Headers */,
+				7A5687341B5461BE00243427 /* AEBlockScheduler.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -278,6 +341,23 @@
 			productReference = 4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		7A56870F1B54610900243427 /* TheAmazingAudioEngine OS X */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7A5687111B54610900243427 /* Build configuration list for PBXNativeTarget "TheAmazingAudioEngine OS X" */;
+			buildPhases = (
+				7A56870C1B54610900243427 /* Sources */,
+				7A56870D1B54610900243427 /* Frameworks */,
+				7A56870E1B54610900243427 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TheAmazingAudioEngine OS X";
+			productName = "TheAmazingAudioEngine OS X";
+			productReference = 7A5687101B54610900243427 /* libTheAmazingAudioEngine OS X.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -286,6 +366,11 @@
 			attributes = {
 				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = "A Tasty Pixel";
+				TargetAttributes = {
+					7A56870F1B54610900243427 = {
+						CreatedOnToolsVersion = 6.4;
+					};
+				};
 			};
 			buildConfigurationList = 4CE501861493F82600F23607 /* Build configuration list for PBXProject "TheAmazingAudioEngine" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -300,6 +385,7 @@
 			projectRoot = "";
 			targets = (
 				4C215CEB1523A7D500D36CAD /* TheAmazingAudioEngine */,
+				7A56870F1B54610900243427 /* TheAmazingAudioEngine OS X */,
 			);
 		};
 /* End PBXProject section */
@@ -355,6 +441,28 @@
 				4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */,
 				4C456B8E16D59365008ED99D /* AEBlockAudioReceiver.m in Sources */,
 				4C09450216FBD7460054608E /* AEBlockScheduler.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7A56870C1B54610900243427 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A5687141B54617200243427 /* AEAudioController.m in Sources */,
+				7A5687151B54617200243427 /* AEAudioController+Audiobus.m in Sources */,
+				7A5687161B54617200243427 /* AEAudioFilePlayer.m in Sources */,
+				7A5687171B54617200243427 /* AEAudioFileWriter.m in Sources */,
+				7A5687181B54617200243427 /* AEUtilities.c in Sources */,
+				7A5687191B54617200243427 /* AEBlockChannel.m in Sources */,
+				7A56871A1B54617200243427 /* AEAudioUnitFilter.m in Sources */,
+				7A56871B1B54617200243427 /* AEAudioUnitChannel.m in Sources */,
+				7A56871C1B54617200243427 /* AEBlockFilter.m in Sources */,
+				7A56871D1B54617200243427 /* AEBlockAudioReceiver.m in Sources */,
+				7A56871E1B54617200243427 /* AEFloatConverter.m in Sources */,
+				7A56871F1B54617200243427 /* AEAudioFileLoaderOperation.m in Sources */,
+				7A5687201B54617200243427 /* TPCircularBuffer.c in Sources */,
+				7A5687221B54618B00243427 /* TPCircularBuffer+AudioBufferList.c in Sources */,
+				7A5687211B54617200243427 /* AEBlockScheduler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -480,6 +588,107 @@
 			};
 			name = Release;
 		};
+		7A5687121B54610900243427 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "TheAmazingAudioEngine/TheAmazingAudioEngine-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-DTPCircularBuffer=AECB",
+					"-DTPCircularBufferInit=AECBInit",
+					"-DTPCircularBufferCleanup=AECBClean",
+					"-DTPCircularBufferClear=AECBClear",
+					"-DTPCircularBufferTail=AECBTail",
+					"-DTPCircularBufferConsume=AECBConsume",
+					"-DTPCircularBufferHead=AECBHead",
+					"-DTPCircularBufferProduce=AECBProduce",
+					"-DTPCircularBufferProduceBytes=AECBProduceBytes",
+					"-DTPCircularBufferPrepareEmptyAudioBufferList=AECBPrepareEmptyBL",
+					"-DTPCircularBufferPrepareEmptyAudioBufferListWithAudioFormat=AECBPrepareEmptyBLWithAF",
+					"-DTPCircularBufferProduceAudioBufferList=AECBProduceBL",
+					"-DTPCircularBufferCopyAudioBufferList=AECBCopyBL",
+					"-DTPCircularBufferNextBufferList=AECBNextBL",
+					"-DTPCircularBufferNextBufferListAfter=AECBNextBLAfter",
+					"-DTPCircularBufferConsumeNextBufferList=AECBConsumeBL",
+					"-DTPCircularBufferConsumeNextBufferListPartial=AECBConsumeBLPartial",
+					"-DTPCircularBufferDequeueBufferListFrames=AECBDequeueBLFrames",
+					"-DTPCircularBufferPeek=AECBPeek",
+					"-DTPCircularBufferPeekContiguous=AECBPeekContiguous",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		7A5687131B54610900243427 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "TheAmazingAudioEngine/TheAmazingAudioEngine-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-DTPCircularBuffer=AECB",
+					"-DTPCircularBufferInit=AECBInit",
+					"-DTPCircularBufferCleanup=AECBClean",
+					"-DTPCircularBufferClear=AECBClear",
+					"-DTPCircularBufferTail=AECBTail",
+					"-DTPCircularBufferConsume=AECBConsume",
+					"-DTPCircularBufferHead=AECBHead",
+					"-DTPCircularBufferProduce=AECBProduce",
+					"-DTPCircularBufferProduceBytes=AECBProduceBytes",
+					"-DTPCircularBufferPrepareEmptyAudioBufferList=AECBPrepareEmptyBL",
+					"-DTPCircularBufferPrepareEmptyAudioBufferListWithAudioFormat=AECBPrepareEmptyBLWithAF",
+					"-DTPCircularBufferProduceAudioBufferList=AECBProduceBL",
+					"-DTPCircularBufferCopyAudioBufferList=AECBCopyBL",
+					"-DTPCircularBufferNextBufferList=AECBNextBL",
+					"-DTPCircularBufferNextBufferListAfter=AECBNextBLAfter",
+					"-DTPCircularBufferConsumeNextBufferList=AECBConsumeBL",
+					"-DTPCircularBufferConsumeNextBufferListPartial=AECBConsumeBLPartial",
+					"-DTPCircularBufferDequeueBufferListFrames=AECBDequeueBLFrames",
+					"-DTPCircularBufferPeek=AECBPeek",
+					"-DTPCircularBufferPeekContiguous=AECBPeekContiguous",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -497,6 +706,15 @@
 			buildConfigurations = (
 				4CE501981493F82600F23607 /* Debug */,
 				4CE501991493F82600F23607 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7A5687111B54610900243427 /* Build configuration list for PBXNativeTarget "TheAmazingAudioEngine OS X" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A5687121B54610900243427 /* Debug */,
+				7A5687131B54610900243427 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -29,6 +29,7 @@ extern "C" {
 
 #import <AudioToolbox/AudioToolbox.h>
 #import <AudioUnit/AudioUnit.h>
+#import <Foundation/Foundation.h>
 
 @class AEAudioController;
 
@@ -1133,7 +1134,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *  The default value is AVAudioSessionCategoryPlayAndRecord if audio input is enabled, or
  *  AVAudioSessionCategoryPlayback otherwise, with mixing with other apps enabled.
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, assign) NSString * audioSessionCategory;
+#endif
 
 /*!
  * Whether to allow mixing audio with other apps
@@ -1146,7 +1149,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *
  *  Default: YES
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, assign) BOOL allowMixingWithOtherApps;
+#endif
 
 /*!
  * Whether to use the "Measurement" Audio Session Mode for improved audio quality and bass response.
@@ -1155,7 +1160,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *
  * Default: NO
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, assign) BOOL useMeasurementMode;
+#endif
 
 /*!
  * Whether to avoid using Measurement Mode with the built-in mic
@@ -1166,7 +1173,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *
  *  Default is YES.
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, assign) BOOL avoidMeasurementModeForBuiltInMic;
+#endif
 
 /*! 
  * Mute output
@@ -1291,7 +1300,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *  The currently-reported hardware input latency.
  *  See AEAudioControllerInputLatency.
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, readonly) NSTimeInterval inputLatency;
+#endif
 
 /*!
  * Output latency (in seconds)
@@ -1299,7 +1310,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *  The currently-reported hardware output latency.
  *  See AEAudioControllerOutputLatency
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, readonly) NSTimeInterval outputLatency;
+#endif
 
 /*!
  * Whether to automatically account for input/output latency
@@ -1313,7 +1326,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  *
  *  Default is NO.
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, assign) BOOL automaticLatencyManagement;
+#endif
 
 /*!
  * Determine whether the audio engine is running
@@ -1395,7 +1410,9 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  * @param controller The audio controller
  * @returns The currently-reported hardware input latency
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 NSTimeInterval AEAudioControllerInputLatency(__unsafe_unretained AEAudioController *controller);
+#endif
 
 /*!
  * Output latency (in seconds)
@@ -1411,7 +1428,9 @@ NSTimeInterval AEAudioControllerInputLatency(__unsafe_unretained AEAudioControll
  * @param controller The audio controller
  * @returns The currently-reported hardware output latency
  */
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 NSTimeInterval AEAudioControllerOutputLatency(__unsafe_unretained AEAudioController *controller);
+#endif
 
 /*!
  * Get the current audio system timestamp

--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -29,7 +29,6 @@ extern "C" {
 
 #import <AudioToolbox/AudioToolbox.h>
 #import <AudioUnit/AudioUnit.h>
-#import <Foundation/Foundation.h>
 
 @class AEAudioController;
 

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2706,7 +2706,6 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
 - (void)configureAudioUnit {
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-#endif
     if ( _inputEnabled ) {
         // Enable input
         UInt32 enableInputFlag = 1;
@@ -2725,6 +2724,7 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
         OSStatus result = AudioUnitSetProperty(_ioAudioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &enableInputFlag, sizeof(enableInputFlag));
         checkResult(result, "AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)");
     }
+#endif
 
     if (!_outputEnabled) {
         // disable output
@@ -2854,6 +2854,11 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
 - (BOOL)updateInputDeviceStatus {
     if ( !_audioGraph ) return NO;
     NSAssert(_inputEnabled, @"Input must be enabled");
+    
+#if TARGET_OS_MAC
+    NSLog(@"TAAE: Warning: Audio input is not yet implemented on OS X");
+    return NO;
+#endif
     
     BOOL success = YES;
     BOOL inputAvailable = NO;

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -56,7 +56,6 @@ static const int kMaximumMonitoringChannels            = 16;
 static const NSTimeInterval kMaxBufferDurationWithVPIO = 0.01;
 static const Float32 kNoValue                          = -1.0;
 #endif
-
 #define kNoAudioErr                            -2222
 
 static void * kChannelPropertyChanged = &kChannelPropertyChanged;

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -25,7 +25,9 @@
 
 #import "AEAudioController.h"
 #import "AEUtilities.h"
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 #import <UIKit/UIKit.h>
+#endif
 #import <AVFoundation/AVFoundation.h>
 #import <libkern/OSAtomic.h>
 #import "TPCircularBuffer.h"
@@ -50,14 +52,19 @@ static const int kScratchBufferFrames                  = kMaxFramesPerSlice;
 static const int kInputAudioBufferFrames               = kMaxFramesPerSlice;
 static const int kLevelMonitorScratchBufferSize        = kMaxFramesPerSlice;
 static const int kMaximumMonitoringChannels            = 16;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 static const NSTimeInterval kMaxBufferDurationWithVPIO = 0.01;
 static const Float32 kNoValue                          = -1.0;
+#endif
+
 #define kNoAudioErr                            -2222
 
 static void * kChannelPropertyChanged = &kChannelPropertyChanged;
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 static Float32 __cachedInputLatency = kNoValue;
 static Float32 __cachedOutputLatency = kNoValue;
+#endif
 
 NSString * const AEAudioControllerSessionInterruptionBeganNotification = @"com.theamazingaudioengine.AEAudioControllerSessionInterruptionBeganNotification";
 NSString * const AEAudioControllerSessionInterruptionEndedNotification = @"com.theamazingaudioengine.AEAudioControllerSessionInterruptionEndedNotification";
@@ -304,7 +311,9 @@ typedef struct {
 
 @property (nonatomic, assign, readwrite) NSTimeInterval currentBufferDuration;
 @property (nonatomic, strong) NSError *lastError;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic, strong) NSTimer *housekeepingTimer;
+#endif
 @property (nonatomic, strong) ABReceiverPort *audiobusReceiverPort;
 @property (nonatomic, strong) ABFilterPort *audiobusFilterPort;
 @property (nonatomic, strong) ABSenderPort *audiobusSenderPort;
@@ -312,7 +321,9 @@ typedef struct {
 @end
 
 @implementation AEAudioController
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @synthesize audioSessionCategory = _audioSessionCategory, audioUnit = _ioAudioUnit;
+#endif
 @dynamic running, inputGainAvailable, inputGain, audiobusSenderPort, inputAudioDescription, inputChannelSelection;
 
 #pragma mark -
@@ -403,11 +414,12 @@ static OSStatus renderCallback(void *inRefCon, AudioUnitRenderActionFlags *ioAct
     }
     
     AudioTimeStamp timestamp = *inTimeStamp;
-    
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     if ( THIS->_automaticLatencyManagement ) {
         // Adjust timestamp to factor in hardware output latency
         timestamp.mHostTime += AEHostTicksFromSeconds(AEAudioControllerOutputLatency(THIS));
     }
+#endif
     
     if ( channel->timeStamp.mFlags == 0 ) {
         channel->timeStamp = timestamp;
@@ -573,10 +585,12 @@ static OSStatus topRenderNotifyCallback(void *inRefCon, AudioUnitRenderActionFla
         
         // Perform timing callbacks
         AudioTimeStamp timestamp = *inTimeStamp;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( THIS->_automaticLatencyManagement ) {
             // Adjust timestamp to factor in hardware output latency
             timestamp.mHostTime += AEHostTicksFromSeconds(AEAudioControllerOutputLatency(THIS));
         }
+#endif
         
         THIS->_lastInputOrOutputBusTimeStamp = timestamp;
         
@@ -615,20 +629,24 @@ static void serviceAudioInput(__unsafe_unretained AEAudioController * THIS, cons
     if ( useAudiobusReceiverPort ) {
         // If Audiobus is connected, then serve Audiobus queue rather than serving system input queue
         timestamp = outputBusTimeStamp ? *outputBusTimeStamp : *inputBusTimeStamp;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( outputBusTimeStamp && THIS->_automaticLatencyManagement ) {
             // Adjust timestamp to factor in hardware output latency
             timestamp.mHostTime += AEHostTicksFromSeconds(AEAudioControllerOutputLatency(THIS));
         }
+#endif
         static Float64 __sampleTime = 0;
         ABReceiverPortReceive(THIS->_audiobusReceiverPort, nil, THIS->_inputAudioBufferList, inNumberFrames, &timestamp);
         timestamp.mSampleTime = __sampleTime;
         __sampleTime += inNumberFrames;
     } else {
         timestamp = *inputBusTimeStamp;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( THIS->_automaticLatencyManagement ) {
             // Adjust timestamp to factor in hardware input latency
             timestamp.mHostTime -= AEHostTicksFromSeconds(AEAudioControllerInputLatency(THIS));
         }
+#endif
     }
     
     THIS->_lastInputOrOutputBusTimeStamp = timestamp;
@@ -837,8 +855,11 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
     
     NSAssert(audioDescription.mFormatID == kAudioFormatLinearPCM, @"Only linear PCM supported");
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     _audioSessionCategory = enableInput ? (enableOutput ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategoryRecord) : AVAudioSessionCategoryPlayback;
     _allowMixingWithOtherApps = enableOutput ? YES : NO;
+    _avoidMeasurementModeForBuiltInMic = YES;
+#endif
     _audioDescription = audioDescription;
     _inputEnabled = enableInput;
     _outputEnabled = enableOutput;
@@ -846,11 +867,12 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
     _voiceProcessingEnabled = useVoiceProcessing;
     _inputMode = AEInputModeFixedAudioFormat;
     _voiceProcessingOnlyForSpeakerAndMicrophone = YES;
-    _avoidMeasurementModeForBuiltInMic = YES;
     _inputCallbacks = (input_callback_table_t*)calloc(sizeof(input_callback_table_t), 1);
     _inputCallbackCount = 1;
     
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+#endif
     
     if ( ABConnectionsChangedNotification ) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audiobusConnectionsChanged:) name:ABConnectionsChangedNotification object:nil];
@@ -859,17 +881,21 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
     TPCircularBufferInit(&_realtimeThreadMessageBuffer, kMessageBufferLength);
     TPCircularBufferInit(&_mainThreadMessageBuffer, kMessageBufferLength);
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     // Register for notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptionNotification:) name:AVAudioSessionInterruptionNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioRouteChangeNotification:) name:AVAudioSessionRouteChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(mediaServiceResetNotification:) name:AVAudioSessionMediaServicesWereResetNotification object:nil];
-
+#endif
+    
     if ( ![self initAudioSession] || ![self setup] ) {
         _audioGraph = NULL;
     }
     
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     self.housekeepingTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:[[AEAudioControllerProxy alloc] initWithAudioController:self] selector:@selector(housekeeping) userInfo:nil repeats:YES];
-    
+#endif
+
     return self;
 }
 
@@ -886,8 +912,11 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
 
     [NSThread sleepForTimeInterval:0.5];
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     _audioSessionCategory = enableInput ? (enableOutput ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategoryRecord) : AVAudioSessionCategoryPlayback;
     _allowMixingWithOtherApps = enableOutput ? YES : NO;
+    _avoidMeasurementModeForBuiltInMic = YES;
+#endif
     _audioDescription = audioDescription;
     _inputEnabled = enableInput;
     _outputEnabled = enableOutput;
@@ -895,8 +924,6 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
     _voiceProcessingEnabled = useVoiceProcessing;
     _inputMode = AEInputModeFixedAudioFormat;
     _voiceProcessingOnlyForSpeakerAndMicrophone = YES;
-    _avoidMeasurementModeForBuiltInMic = YES;
-
 
     if ( ![self initAudioSession] || ![self setup] ) {
         NSLog(@"TAAE: error setting up audio session");
@@ -920,9 +947,10 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
 - (void)dealloc {
     __AEAllocated = NO;
     
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     [_housekeepingTimer invalidate];
     self.housekeepingTimer = nil;
-    
+#endif
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
@@ -971,6 +999,7 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
         return NO;
     }
     
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     
     if ( ![audioSession setActive:YES error:error] ) {
@@ -986,6 +1015,13 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
     if ( _outputEnabled ) {
         __cachedOutputLatency = audioSession.outputLatency;
     }
+#else
+    UInt32 bufferFrameSize;
+    UInt32 sizeParam = sizeof(UInt32);
+    AudioUnitGetProperty(_ioAudioUnit, kAudioDevicePropertyBufferFrameSize, kAudioUnitScope_Global, 0, &bufferFrameSize, &sizeParam);
+    NSTimeInterval bufferDuration = (double)bufferFrameSize / (double)self.audioDescription.mSampleRate;
+    if ( _currentBufferDuration != bufferDuration ) self.currentBufferDuration = bufferDuration;
+#endif
     
     _interrupted = NO;
     
@@ -1019,7 +1055,8 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
             checkResult(AudioOutputUnitStart(_ioAudioUnit), "AudioOutputUnitStart");
         }
     }
-    
+
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     if ( _inputEnabled ) {
         if ( [audioSession respondsToSelector:@selector(requestRecordPermission:)] ) {
             [audioSession requestRecordPermission:^(BOOL granted) {
@@ -1039,6 +1076,8 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
             [self updateInputDeviceStatus];
         }
     }
+#endif
+
     
     _started = YES;
     
@@ -1060,12 +1099,14 @@ static OSStatus ioUnitRenderNotifyCallback(void *inRefCon, AudioUnitRenderAction
         checkResult(AudioOutputUnitStop(_ioAudioUnit), "AudioOutputUnitStop");
     }
     
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     if ( !_interrupted ) {
         NSError *error = nil;
         if ( ![((AVAudioSession*)[AVAudioSession sharedInstance]) setActive:NO error:&error] ) {
             NSLog(@"TAAE: Couldn't deactivate audio session: %@", error);
         }
     }
+#endif
     
     processPendingMessagesOnRealtimeThread(self);
     
@@ -1866,6 +1907,7 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *T
 
 #pragma mark - Setters, getters
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 -(void)setAudioSessionCategory:(NSString *)audioSessionCategory {
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     
@@ -1926,6 +1968,7 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *T
         }
     }
 }
+#endif
 
 -(void)setMasterOutputVolume:(float)masterOutputVolume {
     _masterOutputVolume = masterOutputVolume;
@@ -1945,6 +1988,7 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *T
     }
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 -(void)setEnableBluetoothInput:(BOOL)enableBluetoothInput {
     _enableBluetoothInput = enableBluetoothInput;
 
@@ -1958,17 +2002,20 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *T
 -(float)inputGain {
     return [((AVAudioSession*)[AVAudioSession sharedInstance]) inputGain];
 }
+#endif
 
 -(AudioStreamBasicDescription)inputAudioDescription {
     return _inputCallbacks[0].audioDescription;
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 -(void)setInputGain:(float)inputGain {
     NSError *error = NULL;
     if ( ![((AVAudioSession*)[AVAudioSession sharedInstance]) setInputGain:inputGain error:&error] ) {
         NSLog(@"TAAE: Couldn't set input gain: %@", error);
     }
 }
+#endif
 
 -(void)setInputMode:(AEInputMode)inputMode {
     _inputMode = inputMode;
@@ -1997,6 +2044,7 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *T
     }
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 -(void)setPreferredBufferDuration:(NSTimeInterval)preferredBufferDuration {
     if ( _preferredBufferDuration == preferredBufferDuration ) return;
     
@@ -2061,6 +2109,7 @@ NSTimeInterval AEAudioControllerOutputLatency(__unsafe_unretained AEAudioControl
     }
     return __cachedOutputLatency;
 }
+#endif
 
 AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudioController *THIS) {
     return THIS->_lastInputOrOutputBusTimeStamp;
@@ -2250,6 +2299,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
     }
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 - (void)applicationWillEnterForeground:(NSNotification*)notification {
     NSError *error = nil;
     if ( ![((AVAudioSession*)[AVAudioSession sharedInstance]) setActive:YES error:&error] ) {
@@ -2268,6 +2318,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
     
     if ( _hasSystemError ) [self attemptRecoveryFromSystemError:NULL thenStart:YES];
 }
+#endif
 
 -(void)audiobusConnectionsChanged:(NSNotification*)notification {
     if ( _inputEnabled ) {
@@ -2278,6 +2329,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
     }
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 - (void)interruptionNotification:(NSNotification*)notification {
     dispatch_async(dispatch_get_main_queue(), ^{
         if ( [notification.userInfo[AVAudioSessionInterruptionTypeKey] intValue] == AVAudioSessionInterruptionTypeEnded ) {
@@ -2394,6 +2446,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
                                                           userInfo:notification.userInfo];
     });
 }
+#endif
 
 - (void)mediaServiceResetNotification:(NSNotification*)notification {
     NSError * error = nil;
@@ -2403,6 +2456,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
     }
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, AudioUnitPropertyID inID, AudioUnitScope inScope, AudioUnitElement inElement) {
     @autoreleasepool {
         AEAudioController *THIS = (__bridge AEAudioController*)inRefCon;
@@ -2423,11 +2477,12 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
         }
     }
 }
+#endif
 
 #pragma mark - Graph and audio session configuration
 
-
 - (BOOL)initAudioSession {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     NSMutableString *extraInfo = [NSMutableString string];
     NSError *error = nil;
@@ -2482,6 +2537,7 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     if ( _currentBufferDuration != bufferDuration ) self.currentBufferDuration = bufferDuration;
     
     NSLog(@"TAAE: Audio session initialized (%@) HW samplerate: %g", [extraInfo stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@", "]], achievedSampleRate);
+#endif
     return YES;
 }
 
@@ -2492,10 +2548,21 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     
     BOOL useVoiceProcessing = [self usingVPIO];
     
+    OSType componentSubType;
+    if (useVoiceProcessing) {
+        componentSubType = kAudioUnitSubType_VoiceProcessingIO;
+    } else {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+        componentSubType = kAudioUnitSubType_RemoteIO;
+#else
+        componentSubType = kAudioUnitSubType_DefaultOutput;
+#endif
+    }
+    
     // Input/output unit description
     AudioComponentDescription io_desc = {
         .componentType = kAudioUnitType_Output,
-        .componentSubType = useVoiceProcessing ? kAudioUnitSubType_VoiceProcessingIO : kAudioUnitSubType_RemoteIO,
+        .componentSubType = componentSubType,
         .componentManufacturer = kAudioUnitManufacturer_Apple,
         .componentFlags = 0,
         .componentFlagsMask = 0
@@ -2570,10 +2637,21 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
 - (void)replaceIONode {
     if ( !_topChannel ) return;
     BOOL useVoiceProcessing = [self usingVPIO];
+
+    OSType componentSubType;
+    if (useVoiceProcessing) {
+        componentSubType = kAudioUnitSubType_VoiceProcessingIO;
+    } else {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+        componentSubType = kAudioUnitSubType_RemoteIO;
+#else
+        componentSubType = kAudioUnitSubType_DefaultOutput;
+#endif
+    }
     
     AudioComponentDescription io_desc = {
         .componentType = kAudioUnitType_Output,
-        .componentSubType = useVoiceProcessing ? kAudioUnitSubType_VoiceProcessingIO : kAudioUnitSubType_RemoteIO,
+        .componentSubType = componentSubType,
         .componentManufacturer = kAudioUnitManufacturer_Apple,
         .componentFlags = 0,
         .componentFlagsMask = 0
@@ -2616,8 +2694,9 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
 }
 
 - (void)configureAudioUnit {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-    
+#endif
     if ( _inputEnabled ) {
         // Enable input
         UInt32 enableInputFlag = 1;
@@ -2649,7 +2728,8 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
         UInt32 quality = 127;
         OSStatus result = AudioUnitSetProperty(_ioAudioUnit, kAUVoiceIOProperty_VoiceProcessingQuality, kAudioUnitScope_Global, 0, &quality, sizeof(quality));
         checkResult(result, "AudioUnitSetProperty(kAUVoiceIOProperty_VoiceProcessingQuality)");
-        
+
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( _preferredBufferDuration ) {
             // If we're using voice processing, clamp the buffer duration
             Float32 preferredBufferSize = MAX(kMaxBufferDurationWithVPIO, _preferredBufferDuration);
@@ -2658,7 +2738,9 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
                 NSLog(@"TAAE: Couldn't set preferred IO buffer duration: %@", error);
             }
         }
+#endif
     } else {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( _preferredBufferDuration ) {
             // Set the buffer duration
             NSError *error = nil;
@@ -2666,14 +2748,17 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
                 NSLog(@"TAAE: Couldn't set preferred IO buffer duration: %@", error);
             }
         }
+#endif
     }
     
     // Set the audio unit to handle up to 4096 frames per slice to keep rendering during screen lock
     checkResult(AudioUnitSetProperty(_ioAudioUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &kMaxFramesPerSlice, sizeof(kMaxFramesPerSlice)),
                 "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     checkResult(AudioUnitAddPropertyListener(_ioAudioUnit, kAudioUnitProperty_IsInterAppConnected, interAppConnectedChangeCallback, (__bridge void*)self),
                 "AudioUnitAddPropertyListener(kAudioUnitProperty_IsInterAppConnected)");
+#endif
 }
 
 - (void)teardown {
@@ -2719,9 +2804,20 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     if ( !_audioGraph ) return NO;
     BOOL useVoiceProcessing = [self usingVPIO];
 
+    OSType componentSubType;
+    if (useVoiceProcessing) {
+        componentSubType = kAudioUnitSubType_VoiceProcessingIO;
+    } else {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+        componentSubType = kAudioUnitSubType_RemoteIO;
+#else
+        componentSubType = kAudioUnitSubType_DefaultOutput;
+#endif
+    }
+    
     AudioComponentDescription target_io_desc = {
         .componentType = kAudioUnitType_Output,
-        .componentSubType = useVoiceProcessing ? kAudioUnitSubType_VoiceProcessingIO : kAudioUnitSubType_RemoteIO,
+        .componentSubType = componentSubType,
         .componentManufacturer = kAudioUnitManufacturer_Apple,
         .componentFlags = 0,
         .componentFlagsMask = 0
@@ -2750,14 +2846,18 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     NSAssert(_inputEnabled, @"Input must be enabled");
     
     BOOL success = YES;
+    BOOL inputAvailable = NO;
+    BOOL hardwareInputAvailable = NO;
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-    
-    BOOL inputAvailable          = audioSession.inputAvailable;
-    BOOL hardwareInputAvailable  = inputAvailable;
+    inputAvailable          = audioSession.inputAvailable;
+    hardwareInputAvailable  = inputAvailable;
+    UInt32 usingIAA              = NO;
+#endif
     int numberOfInputChannels    = _audioDescription.mChannelsPerFrame;
     BOOL usingAudiobus           = NO;
-    UInt32 usingIAA              = NO;
-    
+
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     UInt32 size = sizeof(usingIAA);
     AudioUnitGetProperty(_ioAudioUnit, kAudioUnitProperty_IsInterAppConnected, kAudioUnitScope_Global, 0, &usingIAA, &size);
 
@@ -2811,6 +2911,7 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
             }
         }
     }
+#endif
     
     AudioStreamBasicDescription rawAudioDescription = _rawInputAudioDescription;
     AudioBufferList *inputAudioBufferList           = _inputAudioBufferList;
@@ -2874,6 +2975,7 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
                     rawAudioDescription = entry->audioDescription;
                 }
                 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
                 BOOL useVoiceProcessing = [self usingVPIO];
                 if ( useVoiceProcessing && (_audioDescription.mFormatFlags & kAudioFormatFlagIsNonInterleaved) && [[[UIDevice currentDevice] systemVersion] floatValue] < 5.0 ) {
                     // iOS 4 cannot handle non-interleaved audio and voice processing. Use interleaved audio and a converter.
@@ -2883,6 +2985,7 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
                     rawAudioDescription.mBytesPerFrame *= rawAudioDescription.mChannelsPerFrame;
                     rawAudioDescription.mBytesPerPacket *= rawAudioDescription.mChannelsPerFrame;
                 }
+#endif
                 
                 if ( inputLevelMonitorData.monitoringEnabled && memcmp(&_rawInputAudioDescription, &rawAudioDescription, sizeof(_rawInputAudioDescription)) != 0 ) {
                     inputLevelMonitorData.channels = rawAudioDescription.mChannelsPerFrame;
@@ -2953,10 +3056,12 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
         }
         
     } else if ( !inputAvailable ) {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
         if ( [_audioSessionCategory isEqualToString:AVAudioSessionCategoryPlayAndRecord] || [_audioSessionCategory isEqualToString:AVAudioSessionCategoryRecord] ) {
             // Update audio session as appropriate (will select a non-recording category for us)
             self.audioSessionCategory = _audioSessionCategory;
         }
+#endif
         
         inputAudioBufferList = NULL;
         
@@ -3780,6 +3885,7 @@ static BOOL upstreamChannelsConnectedToAudiobus(AEChannelRef channel) {
     return upstreamChannelsConnectedToAudiobus(parentGroupChannel);
 }
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 static void * firstUpstreamAudiobusSenderPort(AEChannelRef channel) {
     if ( channel->audiobusSenderPort ) {
         return channel->audiobusSenderPort;
@@ -3789,7 +3895,9 @@ static void * firstUpstreamAudiobusSenderPort(AEChannelRef channel) {
     
     return firstUpstreamAudiobusSenderPort(channel->parentGroup->channel);
 }
+#endif
 
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 - (void)housekeeping {
     Float32 bufferDuration = [((AVAudioSession*)[AVAudioSession sharedInstance]) IOBufferDuration];
     if ( _currentBufferDuration != bufferDuration ) self.currentBufferDuration = bufferDuration;
@@ -3808,6 +3916,7 @@ static void * firstUpstreamAudiobusSenderPort(AEChannelRef channel) {
     
     return [NSString stringWithFormat:@"%@%@%@", inputsString, inputsString.length > 0 && outputsString.length > 0 ? @" and " : @"", outputsString];
 }
+#endif
 
 @end
 


### PR DESCRIPTION
This adds support for audio output on OS X. I added this support with minimal possible refactoring. Input support for OS X will require more significant changes.

What changes would we need to make to add permanent support for OS X in TAAE?