### PR TITLE
feature/osx: AEAudioFilePlayer: add postRenderBlock() and expose lengthInFrames

### DIFF
--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -74,7 +74,7 @@
 		4C09450016FBD7460054608E /* AEBlockScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockScheduler.m; sourceTree = "<group>"; };
 		4C12CC98151D1EDA00562E2A /* AEUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEUtilities.h; sourceTree = "<group>"; };
 		4C12CC99151D1EDA00562E2A /* AEUtilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = AEUtilities.c; sourceTree = "<group>"; };
-		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libTheAmazingAudioEngine.a; path = "libTheAmazingAudioEngine iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTheAmazingAudioEngine.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C215CEE1523A7D500D36CAD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4C23241F15AC5E2600038EC0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4C23242215AC5E2600038EC0 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -212,6 +212,7 @@
 				4CE501901493F82600F23607 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		4CE501901493F82600F23607 /* Products */ = {
 			isa = PBXGroup;

--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -30,6 +30,8 @@ extern "C" {
 #import <AudioToolbox/AudioToolbox.h>
 #import <AudioUnit/AudioUnit.h>
 
+#import <Foundation/NSDate.h>
+
 @class AEAudioController;
 
 #pragma mark - Notifications and constants

--- a/TheAmazingAudioEngine/AEAudioFilePlayer.h
+++ b/TheAmazingAudioEngine/AEAudioFilePlayer.h
@@ -30,6 +30,8 @@ extern "C" {
 #import <Foundation/Foundation.h>
 #import "AEAudioController.h"
 
+typedef void (^AEFilePostRenderBlock)(UInt32 playhead, UInt32 frames, AudioBufferList *audio);
+
 /*!
  * Audio file player
  *
@@ -52,6 +54,7 @@ extern "C" {
 
 @property (nonatomic, strong, readonly) NSURL *url;         //!< Original media URL
 @property (nonatomic, readonly) NSTimeInterval duration;    //!< Length of audio, in seconds
+@property (nonatomic, readonly) UInt32 lengthInFrames;      //!< Length of audio, in frames
 @property (nonatomic, assign) NSTimeInterval currentTime;   //!< Current playback position, in seconds
 @property (nonatomic, readwrite) BOOL loop;                 //!< Whether to loop this track
 @property (nonatomic, readwrite) float volume;              //!< Track volume
@@ -61,6 +64,7 @@ extern "C" {
 @property (nonatomic, readwrite) BOOL removeUponFinish;     //!< Whether the track automatically removes itself from the audio controller after playback completes
 @property (nonatomic, copy) void(^completionBlock)();       //!< A block to be called when playback finishes
 @property (nonatomic, copy) void(^startLoopBlock)();        //!< A block to be called when the loop restarts in loop mode
+@property (nonatomic, copy) AEFilePostRenderBlock postRenderBlock;  //!< A block to be called for additional post-processing of file data during playback; this is a high-priority block, therefore no I/O or Objective-C messaging is permitted
 @end
 
 #ifdef __cplusplus

--- a/TheAmazingAudioEngine/AEAudioFilePlayer.m
+++ b/TheAmazingAudioEngine/AEAudioFilePlayer.m
@@ -34,7 +34,6 @@
 
 @interface AEAudioFilePlayer () {
     AudioBufferList              *_audio;
-    UInt32                        _lengthInFrames;
     AudioStreamBasicDescription   _audioDescription;
     volatile int32_t              _playhead;
 }
@@ -169,7 +168,10 @@ static OSStatus renderCallback(__unsafe_unretained AEAudioFilePlayer *THIS, __un
     }
     
     OSAtomicCompareAndSwap32(originalPlayhead, playhead, &THIS->_playhead);
-    
+
+    if (THIS->_postRenderBlock)
+        THIS->_postRenderBlock(originalPlayhead, frames, audio);
+
     return noErr;
 }
 


### PR DESCRIPTION
Why is this needed?

Consider you need to apply an envelope or other time-based effect on a file and you play it in a loop, and on top of that the user can move currentTime arbitrarily. To ensure your effect is applied at exact right times, with frame precision, you'd need to know the current frame position in a file in your render routine. However, exposing AEAudioFilePlayer's _playhead directly may not be a very good idea.

On the other hand, there's AEAudioFilePlayer.currentTime, from which you can derive the playhead position, but you don't want to access a public property from within your high-priotiy code.

I suggest, instead, to provide a high-priority callback block (postRenderBlock) that's called at the end of the AEAudioFilePlayer's render routine and takes a copy of _playhead as an argument (actually it takes originalPlayhead, which is the value of _playhead at the beginning of the render callback).

Additionally this patch exposes lengthInFrames as a read-only property. This is not absolutely necessary though, as there is the duration property, but still.

This small addition can greatly simplify e.g. your envelope implementation. Mine took literally a couple of dozen lines.

Unless I'm missing something about TAAE of course. Please feel free to criticize!