### PR TITLE
Add AEAudioUnitFilePlayer for streaming file playback

### DIFF
--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */; };
 		4CEC0EB916B5294300D11ED9 /* AEBlockFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CEC0EBA16B5294300D11ED9 /* AEBlockFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */; };
+		94F5199F1B7801E300944F63 /* AEAudioUnitFilePlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 94F5199D1B7801E300944F63 /* AEAudioUnitFilePlayer.h */; };
+		94F519A01B7801E300944F63 /* AEAudioUnitFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 94F5199E1B7801E300944F63 /* AEAudioUnitFilePlayer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +97,8 @@
 		4CE501971493F82600F23607 /* TheAmazingAudioEngine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TheAmazingAudioEngine-Prefix.pch"; sourceTree = "<group>"; };
 		4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEBlockFilter.h; sourceTree = "<group>"; };
 		4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockFilter.m; sourceTree = "<group>"; };
+		94F5199D1B7801E300944F63 /* AEAudioUnitFilePlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioUnitFilePlayer.h; sourceTree = "<group>"; };
+		94F5199E1B7801E300944F63 /* AEAudioUnitFilePlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEAudioUnitFilePlayer.m; sourceTree = "<group>"; };
 		B0EE36FC1AD4270400D7AB17 /* AESequencerBeat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerBeat.h; sourceTree = "<group>"; };
 		B0EE36FD1AD4270400D7AB17 /* AESequencerBeat.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AESequencerBeat.m; sourceTree = "<group>"; };
 		B0EE36FE1AD4270400D7AB17 /* AESequencerChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerChannel.h; sourceTree = "<group>"; };
@@ -201,6 +205,8 @@
 				4C99588C16C0825F0011FB01 /* AEAudioUnitFilter.m */,
 				4C99588316BB74720011FB01 /* AEAudioUnitChannel.h */,
 				4C99588416BB74720011FB01 /* AEAudioUnitChannel.m */,
+				94F5199D1B7801E300944F63 /* AEAudioUnitFilePlayer.h */,
+				94F5199E1B7801E300944F63 /* AEAudioUnitFilePlayer.m */,
 				4CEC0EB716B5294200D11ED9 /* AEBlockFilter.h */,
 				4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */,
 				4C456B8B16D59365008ED99D /* AEBlockAudioReceiver.h */,
@@ -240,6 +246,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C215D121523A94200D36CAD /* TheAmazingAudioEngine.h in Headers */,
+				94F5199F1B7801E300944F63 /* AEAudioUnitFilePlayer.h in Headers */,
 				4C2886381556FC620074175A /* AEAudioController+Audiobus.h in Headers */,
 				4C215D131523A94200D36CAD /* AEAudioController.h in Headers */,
 				4C49FE32153DC21A008725E0 /* AEAudioFileLoaderOperation.h in Headers */,
@@ -344,6 +351,7 @@
 				4C215D091523A8E500D36CAD /* AEAudioFilePlayer.m in Sources */,
 				4C215D0A1523A8E500D36CAD /* AEUtilities.c in Sources */,
 				4C49FE34153DC21A008725E0 /* AEAudioFileLoaderOperation.m in Sources */,
+				94F519A01B7801E300944F63 /* AEAudioUnitFilePlayer.m in Sources */,
 				4C38DC5715458AB1009F4454 /* AEAudioFileWriter.m in Sources */,
 				4C2886521557DB800074175A /* AEAudioController+Audiobus.m in Sources */,
 				4C25747415F0D8E100D232E8 /* TPCircularBuffer.c in Sources */,

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.h
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.h
@@ -104,6 +104,11 @@ AudioUnit AEAudioUnitChannelGetAudioUnit(__unsafe_unretained AEAudioUnitChannel 
  */
 @property (nonatomic, readonly) AudioUnit audioUnit;
 
+/*!
+ * The converter unit
+ */
+@property (nonatomic, readonly) AudioUnit converterUnit;
+
 @end
 
 #ifdef __cplusplus

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.h
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #import <Foundation/Foundation.h>
-#import "TheAmazingAudioEngine.h"
+#import "AEAudioController.h"
 
 /*!
  * Audio Unit Channel

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.m
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.m
@@ -146,14 +146,18 @@ AudioUnit AEAudioUnitChannelGetAudioUnit(__unsafe_unretained AEAudioUnitChannel 
     }
 }
 
--(void)dealloc {
+- (void)dealloc {
     if ( _audioUnit ) {
         [self teardown];
     }
 }
 
--(AudioUnit)audioUnit {
+- (AudioUnit)audioUnit {
     return _audioUnit;
+}
+
+- (AudioUnit)converterUnit {
+    return _converterUnit;
 }
 
 static OSStatus renderCallback(__unsafe_unretained AEAudioUnitChannel *THIS,

--- a/TheAmazingAudioEngine/AEAudioUnitChannel.m
+++ b/TheAmazingAudioEngine/AEAudioUnitChannel.m
@@ -24,6 +24,7 @@
 //
 
 #import "AEAudioUnitChannel.h"
+#import "AEUtilities.h"
 
 #define checkResult(result,operation) (_checkResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
 static inline BOOL _checkResult(OSStatus result, const char *operation, const char* file, int line) {

--- a/TheAmazingAudioEngine/AEAudioUnitFilePlayer.h
+++ b/TheAmazingAudioEngine/AEAudioUnitFilePlayer.h
@@ -1,0 +1,53 @@
+//
+//  AEAudioUnitFilePlayer.h
+//  TheAmazingAudioEngine
+//
+//  Created by Ryan Holmes on 8/9/15.
+//  Copyright (c) 2015 A Tasty Pixel. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#import "AEAudioUnitChannel.h"
+#import "AEAudioController.h"
+
+/*!
+ * Audio Unit file player
+ *
+ *  This class allows you to play audio files, either as one-off samples, or looped.
+ *  It will play any audio file format supported by iOS. It uses an AUAudioFilePlayer 
+ *  to stream audio files from disk, so it's a good choice for large files that you 
+ *  don't want to load into memory all at once.
+ *
+ *  To use, create an instance, then add it to the audio controller.
+ */
+
+@interface AEAudioUnitFilePlayer : AEAudioUnitChannel
+
++ (instancetype)audioUnitFilePlayerWithURL:(NSURL *)url error:(NSError **)error;
+- (instancetype)initWithURL:(NSURL *)url error:(NSError **)error;
+
+@property (nonatomic, strong, readonly) NSURL *url;         //!< Original media URL
+@property (nonatomic, readonly) NSTimeInterval duration;    //!< Length of audio, in seconds
+@property (nonatomic, assign) NSTimeInterval currentTime;   //!< Current playback position, in seconds
+@property (nonatomic, readwrite) BOOL loop;                 //!< Whether to loop this track
+@property (nonatomic, readwrite) BOOL removeUponFinish;     //!< Whether the track automatically removes itself from the audio controller after playback completes
+@property (nonatomic, copy) void(^completionBlock)();       //!< A block to be called when playback finishes
+@property (nonatomic, copy) void(^startLoopBlock)();        //!< A block to be called when the loop restarts in loop
+@end

--- a/TheAmazingAudioEngine/AEAudioUnitFilePlayer.m
+++ b/TheAmazingAudioEngine/AEAudioUnitFilePlayer.m
@@ -1,0 +1,311 @@
+//
+//  AEAudioUnitFilePlayer.m
+//  TheAmazingAudioEngine
+//
+//  Created by Ryan Holmes on 8/9/15.
+//  Copyright (c) 2015 A Tasty Pixel. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#import "AEAudioUnitFilePlayer.h"
+#import "AEUtilities.h"
+#import <libkern/OSAtomic.h>
+
+#define checkResult(result,operation) (_checkResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
+static inline BOOL _checkResult(OSStatus result, const char *operation, const char* file, int line) {
+    if ( result != noErr ) {
+        int fourCC = CFSwapInt32HostToBig(result);
+        NSLog(@"%s:%d: %s result %d %08X %4.4s\n", file, line, operation, (int)result, (int)result, (char*)&fourCC);
+        return NO;
+    }
+    return YES;
+}
+
+@interface AEAudioUnitFilePlayer () {
+    AudioUnit _audioUnit;
+    AudioUnit _converterUnit;
+    AudioFileID _audioFileID;
+    UInt32 _lengthInFrames;
+    AudioStreamBasicDescription _audioDescription;
+    AudioStreamBasicDescription _fileAudioDescription;
+    BOOL _channelIsPlaying;
+    volatile int32_t _playhead;
+}
+@property (nonatomic, strong, readwrite) NSURL *url;
+
+@end
+
+@implementation AEAudioUnitFilePlayer
+
++ (instancetype)audioUnitFilePlayerWithURL:(NSURL *)url error:(NSError **)error {
+    return [[self alloc] initWithURL:url error:error];
+}
+
+- (instancetype)initWithURL:(NSURL *)url error:(NSError **)error {
+    
+    AudioComponentDescription audioFilePlayerDescription = AEAudioComponentDescriptionMake(kAudioUnitManufacturer_Apple, kAudioUnitType_Generator, kAudioUnitSubType_AudioFilePlayer);
+    
+    self = [super initWithComponentDescription:audioFilePlayerDescription];
+    if (self != nil) {
+        _url = url;
+    }
+    
+    if ( ![self loadFileFromURL:url error:error] ) {
+        return  nil;
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    if ( _audioFileID ) {
+        AudioFileClose(_audioFileID);
+    }
+}
+
+- (NSTimeInterval)duration {
+    return (double)_lengthInFrames / (double)_audioDescription.mSampleRate;
+}
+
+- (NSTimeInterval)currentTime {
+    if (_lengthInFrames == 0) return 0.0;
+    return ((double)_playhead / (double)_lengthInFrames) * [self duration];
+}
+
+- (void)setCurrentTime:(NSTimeInterval)currentTime {
+    if (_lengthInFrames == 0) return;
+    _playhead = (int32_t)((currentTime / [self duration]) * _lengthInFrames) % _lengthInFrames;
+    
+    [self resetAudioUnit];
+    [self playFileRegion];
+}
+
+- (BOOL)channelIsPlaying {
+    return _channelIsPlaying;
+}
+
+- (void)setChannelIsPlaying:(BOOL)channelIsPlaying {
+    if (_channelIsPlaying != channelIsPlaying) {
+        if (channelIsPlaying) {
+            [self playFileRegion];
+        } else {
+            [self resetAudioUnit];
+        }
+        _channelIsPlaying = channelIsPlaying;
+    }
+    [super setChannelIsPlaying:channelIsPlaying];
+}
+
+- (BOOL)loadFileFromURL:(NSURL*)url error:(NSError**)error {
+    OSStatus result;
+    
+    // Open the file
+    result = AudioFileOpenURL((CFURLRef)CFBridgingRetain(url), kAudioFileReadPermission, 0, &_audioFileID);
+    if ( !checkResult(result, "AudioFileOpenURL") ) {
+        *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
+                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Couldn't open the audio file", @"")}];
+        return NO;
+    }
+    
+    // Get the file data format
+    UInt32 size = sizeof(_fileAudioDescription);
+    result = AudioFileGetProperty(_audioFileID, kAudioFilePropertyDataFormat, &size, &_fileAudioDescription);
+    if ( !checkResult(result, "AudioFileGetProperty(kAudioFilePropertyDataFormat)") ) {
+        *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
+                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Couldn't read the audio file", @"")}];
+        return NO;
+        
+    }
+    
+    // Determine length in frames (in original file's sample rate)
+    AudioFilePacketTableInfo packetInfo;
+    size = sizeof(packetInfo);
+    result = AudioFileGetProperty(_audioFileID, kAudioFilePropertyPacketTableInfo, &size, &packetInfo);
+    if ( !checkResult(result, "AudioFileGetProperty(kAudioFilePropertyPacketTableInfo)") ) {
+        size = 0;
+    }
+    
+    UInt64 fileLengthInFrames;
+    if(size > 0) {
+        fileLengthInFrames = packetInfo.mNumberValidFrames;
+    } else {
+        UInt64 packetCount;
+        size = sizeof(packetCount);
+        result = AudioFileGetProperty(_audioFileID, kAudioFilePropertyAudioDataPacketCount, &size, &packetCount);
+        if ( !checkResult(result, "AudioFileGetProperty(kAudioFilePropertyAudioDataPacketCount)") ) {
+            *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
+                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Couldn't read the audio file", @"")}];
+            return NO;
+        }
+        fileLengthInFrames = packetCount * _fileAudioDescription.mFramesPerPacket;
+    }
+    _lengthInFrames = (UInt32)fileLengthInFrames;
+    
+    // Initialize the audio description with the file's data format. We'll update it later
+    // when we're added to an audio controller.
+    _audioDescription = _fileAudioDescription;
+    
+    return YES;
+}
+
+- (void)playFileRegion {
+    
+    if (!_audioUnit || !_audioFileID) {
+        return;
+    }
+    
+    // Calculate the start frame (in original file's sample rate)
+    double sampleRateRatio = _fileAudioDescription.mSampleRate / _audioDescription.mSampleRate;
+    SInt64 startFrame = (SInt64)ceil(_playhead * sampleRateRatio);
+    
+    // Set the file region to play
+    ScheduledAudioFileRegion region;
+    memset (&region.mTimeStamp, 0, sizeof(region.mTimeStamp));
+    region.mTimeStamp.mFlags = kAudioTimeStampSampleTimeValid;
+    region.mTimeStamp.mSampleTime = 0;
+    region.mCompletionProc = NULL;
+    region.mCompletionProcUserData = NULL;
+    region.mAudioFile = _audioFileID;
+    region.mLoopCount = _loop ? (UInt32)-1 : 0;
+    region.mStartFrame = startFrame;
+    region.mFramesToPlay = (UInt32)-1;
+    
+    OSStatus result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_ScheduledFileRegion, kAudioUnitScope_Global, 0, &region, sizeof(region));
+    checkResult(result, "AudioUnitSetProperty(kAudioUnitProperty_ScheduledFileRegion)");
+    
+    // Prime the player by reading some frames from disk
+    UInt32 primeFrames = 0;
+    result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_ScheduledFilePrime, kAudioUnitScope_Global, 0, &primeFrames, sizeof(primeFrames));
+    checkResult(result, "AudioUnitSetProperty(kAudioUnitProperty_ScheduledFilePrime)");
+    
+    // Set the start time (now = -1)
+    AudioTimeStamp startTime;
+    memset (&startTime, 0, sizeof(startTime));
+    startTime.mFlags = kAudioTimeStampSampleTimeValid;
+    startTime.mSampleTime = -1;
+    result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_ScheduleStartTimeStamp, kAudioUnitScope_Global, 0, &startTime, sizeof(startTime));
+    checkResult(result, "AudioUnitSetProperty(kAudioUnitProperty_ScheduleStartTimeStamp)");
+}
+
+- (void)resetAudioUnit {
+    checkResult(AudioUnitReset(_audioUnit, kAudioUnitScope_Global, 0), "AudioUnitReset");
+}
+
+#pragma mark - Playable Protocol
+
+- (void)setupWithAudioController:(AEAudioController *)audioController {
+    [super setupWithAudioController:audioController];
+    
+    _audioUnit = self.audioUnit;
+    _converterUnit = self.converterUnit;
+    
+    // Update the audio description
+    double originalSampleRate = _audioDescription.mSampleRate;
+    _audioDescription = audioController.audioDescription;
+    
+    // Convert the frame length and playhead to the new sample rate
+    double sampleRateRatio = _audioDescription.mSampleRate / originalSampleRate;
+    _lengthInFrames = (UInt32)ceil(_lengthInFrames * sampleRateRatio);
+    _playhead = (int32_t)ceil(_playhead * sampleRateRatio);
+
+    // Set the file to play
+    UInt32 size = sizeof(_audioFileID);
+    OSStatus result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_ScheduledFileIDs, kAudioUnitScope_Global, 0, &_audioFileID, size);
+    checkResult(result, "AudioUnitSetProperty(kAudioUnitProperty_ScheduledFileIDs)");
+    
+    // Play the file region
+    if (self.channelIsPlaying) {
+        [self playFileRegion];
+    }
+}
+
+- (void)teardown {
+    [self resetAudioUnit];
+    [super teardown];
+}
+
+#pragma mark - Render Callback and Notifications
+
+static void notifyLoopRestart(AEAudioController *audioController, void *userInfo, int length) {
+    AEAudioUnitFilePlayer *THIS = (__bridge AEAudioUnitFilePlayer*)*(void**)userInfo;
+    
+    if ( THIS.startLoopBlock ) THIS.startLoopBlock();
+}
+
+static void notifyPlaybackStopped(AEAudioController *audioController, void *userInfo, int length) {
+    AEAudioUnitFilePlayer *THIS = (__bridge AEAudioUnitFilePlayer*)*(void**)userInfo;
+    THIS.channelIsPlaying = NO;
+    
+    if ( THIS->_removeUponFinish ) {
+        [audioController removeChannels:@[THIS]];
+    }
+    
+    if ( THIS.completionBlock ) THIS.completionBlock();
+    
+    THIS->_playhead = 0;
+}
+
+static OSStatus renderCallback(__unsafe_unretained AEAudioUnitFilePlayer *THIS,
+                               __unsafe_unretained AEAudioController *audioController,
+                               const AudioTimeStamp     *time,
+                               UInt32                    frames,
+                               AudioBufferList          *audio) {
+    AudioUnitRenderActionFlags flags = 0;
+    checkResult(AudioUnitRender(THIS->_converterUnit ? THIS->_converterUnit : THIS->_audioUnit, &flags, time, 0, frames, audio), "AudioUnitRender");
+    
+    int32_t playhead = THIS->_playhead;
+    int32_t originalPlayhead = playhead;
+    
+    if ( !THIS->_loop && playhead == THIS->_lengthInFrames ) {
+        // Notify main thread that playback has finished
+        AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyPlaybackStopped, &THIS, sizeof(AEAudioUnitFilePlayer*));
+        return noErr;
+    }
+    
+    // The number of frames left before the end of the audio
+    UInt32 remainingFrames = MIN(frames, THIS->_lengthInFrames - playhead);
+    
+    // Advance playhead
+    playhead += remainingFrames;
+    
+    if ( playhead >= THIS->_lengthInFrames ) {
+        // Reached the end of the audio - either loop, or stop
+        if ( THIS->_loop ) {
+            playhead = 0;
+            if ( THIS->_startLoopBlock ) {
+                // Notify main thread that the loop playback has restarted
+                AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyLoopRestart, &THIS, sizeof(AEAudioUnitFilePlayer*));
+            }
+        } else {
+            // Notify main thread that playback has finished
+            AEAudioControllerSendAsynchronousMessageToMainThread(audioController, notifyPlaybackStopped, &THIS, sizeof(AEAudioUnitFilePlayer*));
+        }
+    }
+    
+    OSAtomicCompareAndSwap32(originalPlayhead, playhead, &THIS->_playhead);
+    
+    return noErr;
+}
+
+-(AEAudioControllerRenderCallback)renderCallback {
+    return renderCallback;
+}
+
+@end

--- a/TheAmazingAudioEngine/TheAmazingAudioEngine.h
+++ b/TheAmazingAudioEngine/TheAmazingAudioEngine.h
@@ -39,6 +39,7 @@ extern "C" {
 #import "AEBlockAudioReceiver.h"
 #import "AEAudioUnitChannel.h"
 #import "AEAudioUnitFilter.h"
+#import "AEAudioUnitFilePlayer.h"
 #import "AEFloatConverter.h"
 #import "AEBlockScheduler.h"
 #import "AEUtilities.h"


### PR DESCRIPTION
This PR adds an audio file player based on AUAudioFilePlayer to TAEE. It has the following features:

* Uses AUAudioFilePlayer to handle all the details of streaming I/O and buffering
* Subclasses AEAudioUnitChannel to avoid duplication of code
* Has all features of AEAudioFilePlayer, including looping, notifications and remove upon finish
* Uses the render callback to accurately detect end of audio and loop restart
* Correctly calculates the frame length for compressed audio files
* Handles files with a different sample rate than the audio controller
* Doesn't require an AEAudioController in the constructor