### PR TITLE
Enable audio input for OSX

### DIFF
--- a/Modules/AEMixerBuffer.m
+++ b/Modules/AEMixerBuffer.m
@@ -1142,6 +1142,11 @@ static OSStatus sourceInputCallback(void *inRefCon, AudioUnitRenderActionFlags *
     if ( !checkResult(AudioUnitSetProperty(_mixerUnit, kAudioUnitProperty_ElementCount, kAudioUnitScope_Input, 0, &busCount, sizeof(busCount)),
                       "AudioUnitSetProperty(kAudioUnitProperty_ElementCount)") ) return;
     
+    // The default volume for the MultiChannelMixer is 0 on OSX and 1 on iOS. ¯\_(ツ)_/¯
+    AudioUnitParameterValue defaultOutputVolume = 1.0;
+    if ( !checkResult(AudioUnitSetParameter(_mixerUnit, kMultiChannelMixerParam_Volume, kAudioUnitScope_Output, 0, defaultOutputVolume, 0),
+                      "AudioUnitSetParameter(kMultiChannelMixerParam_Volume)") ) return;
+    
     // Configure each bus
     for ( int busNumber=0; busNumber<busCount; busNumber++ ) {
         source_t *source = &_table[busNumber];

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2936,6 +2936,11 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     checkResult(DisposeAUGraph(_audioGraph), "DisposeAUGraph");
     _audioGraph = NULL;
     _ioAudioUnit = NULL;
+#if !TARGET_OS_IPHONE
+    checkResult(AudioUnitUninitialize(_iAudioUnit), "AudioUnitUninitialize");
+    checkResult(AudioComponentInstanceDispose(_iAudioUnit), "AudioComponentInstanceDispose");
+    _iAudioUnit = NULL;
+#endif
     
     for ( int i=0; i<_inputCallbackCount; i++ ) {
         if ( _inputCallbacks[i].audioConverter ) {

--- a/TheEngineSample.xcodeproj/project.pbxproj
+++ b/TheEngineSample.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		4C7C680F16F1609800721E60 /* README.markdown in Resources */ = {isa = PBXBuildFile; fileRef = 4C7C680416F1609800721E60 /* README.markdown */; };
 		4C7C681016F1609800721E60 /* TPCircularBuffer+AudioBufferList.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C680516F1609800721E60 /* TPCircularBuffer+AudioBufferList.c */; };
 		4C7C681116F1609800721E60 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C680716F1609800721E60 /* TPCircularBuffer.c */; };
+		7A532D2B1B7C6FA8006056DB /* AEPlaythroughChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C680016F1609800721E60 /* AEPlaythroughChannel.m */; };
 		7A8D23151B72AF9E0054D2B2 /* libTheAmazingAudioEngine OS X.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A8D22F01B72AF250054D2B2 /* libTheAmazingAudioEngine OS X.a */; };
 		7A8D23321B72B4DD0054D2B2 /* AELimiter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C67FA16F1609800721E60 /* AELimiter.m */; };
 		7A8D23331B72B4E20054D2B2 /* AEExpanderFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C67F816F1609800721E60 /* AEExpanderFilter.m */; };
@@ -456,6 +457,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A532D2B1B7C6FA8006056DB /* AEPlaythroughChannel.m in Sources */,
 				4C50FF331B75936000E56620 /* ViewController.m in Sources */,
 				4C50FF321B75936000E56620 /* main.m in Sources */,
 				7AFFB76C1B75307500892749 /* AERecorder.m in Sources */,

--- a/TheEngineSample/OS X/AppDelegate.m
+++ b/TheEngineSample/OS X/AppDelegate.m
@@ -21,7 +21,7 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {    
     // Create an instance of the audio controller, set it up and start it running
-    self.audioController = [[AEAudioController alloc] initWithAudioDescription:[AEAudioController nonInterleavedFloatStereoAudioDescription] inputEnabled:NO];
+    self.audioController = [[AEAudioController alloc] initWithAudioDescription:[AEAudioController nonInterleavedFloatStereoAudioDescription] inputEnabled:YES];
     self.audioController.preferredBufferDuration = 0.005;
     [self.audioController start:NULL];
     


### PR DESCRIPTION
Added additional audio unit to handle input because no audio unit can
handle IO on OSX like remoteIO can on iOS.

Updated the OSX sample app with input and recording capabilities.