### PR TITLE
Convert sample rate on OSX hardware input if necessary

### DIFF
--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -67,6 +67,10 @@
 		7A5687311B5461BE00243427 /* AEFloatConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8AED0216B3644500958034 /* AEFloatConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A5687321B5461BE00243427 /* AEAudioFileLoaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C49FE30153DC21A008725E0 /* AEAudioFileLoaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A5687341B5461BE00243427 /* AEBlockScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0944FF16FBD7460054608E /* AEBlockScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AFE44F61B7E6F5900570689 /* AESampleRateConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AFE44F41B7E6F5900570689 /* AESampleRateConverter.h */; };
+		7AFE44F71B7E6F5900570689 /* AESampleRateConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AFE44F41B7E6F5900570689 /* AESampleRateConverter.h */; };
+		7AFE44F81B7E6F5900570689 /* AESampleRateConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFE44F51B7E6F5900570689 /* AESampleRateConverter.m */; };
+		7AFE44F91B7E6F5900570689 /* AESampleRateConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFE44F51B7E6F5900570689 /* AESampleRateConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,7 +78,7 @@
 		4C09450016FBD7460054608E /* AEBlockScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockScheduler.m; sourceTree = "<group>"; };
 		4C12CC98151D1EDA00562E2A /* AEUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEUtilities.h; sourceTree = "<group>"; };
 		4C12CC99151D1EDA00562E2A /* AEUtilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = AEUtilities.c; sourceTree = "<group>"; };
-		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libTheAmazingAudioEngine.a; path = "libTheAmazingAudioEngine iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C215CEC1523A7D500D36CAD /* libTheAmazingAudioEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTheAmazingAudioEngine.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C215CEE1523A7D500D36CAD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4C23241F15AC5E2600038EC0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4C23242215AC5E2600038EC0 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -127,6 +131,8 @@
 		4CEC0EB816B5294300D11ED9 /* AEBlockFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEBlockFilter.m; sourceTree = "<group>"; };
 		7A5687101B54610900243427 /* libTheAmazingAudioEngine OS X.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libTheAmazingAudioEngine OS X.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A5687231B5461A000243427 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		7AFE44F41B7E6F5900570689 /* AESampleRateConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AESampleRateConverter.h; sourceTree = "<group>"; };
+		7AFE44F51B7E6F5900570689 /* AESampleRateConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AESampleRateConverter.m; sourceTree = "<group>"; };
 		B0EE36FC1AD4270400D7AB17 /* AESequencerBeat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerBeat.h; sourceTree = "<group>"; };
 		B0EE36FD1AD4270400D7AB17 /* AESequencerBeat.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AESequencerBeat.m; sourceTree = "<group>"; };
 		B0EE36FE1AD4270400D7AB17 /* AESequencerChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AESequencerChannel.h; sourceTree = "<group>"; };
@@ -256,6 +262,8 @@
 				4CE501971493F82600F23607 /* TheAmazingAudioEngine-Prefix.pch */,
 				4C0944FF16FBD7460054608E /* AEBlockScheduler.h */,
 				4C09450016FBD7460054608E /* AEBlockScheduler.m */,
+				7AFE44F41B7E6F5900570689 /* AESampleRateConverter.h */,
+				7AFE44F51B7E6F5900570689 /* AESampleRateConverter.m */,
 			);
 			path = TheAmazingAudioEngine;
 			sourceTree = "<group>";
@@ -283,6 +291,7 @@
 			files = (
 				4C215D121523A94200D36CAD /* TheAmazingAudioEngine.h in Headers */,
 				4C2886381556FC620074175A /* AEAudioController+Audiobus.h in Headers */,
+				7AFE44F61B7E6F5900570689 /* AESampleRateConverter.h in Headers */,
 				4C215D131523A94200D36CAD /* AEAudioController.h in Headers */,
 				4C49FE32153DC21A008725E0 /* AEAudioFileLoaderOperation.h in Headers */,
 				4C215D141523A94200D36CAD /* AEAudioFilePlayer.h in Headers */,
@@ -304,6 +313,7 @@
 			files = (
 				7A5687251B5461BE00243427 /* TheAmazingAudioEngine.h in Headers */,
 				7A5687261B5461BE00243427 /* AEAudioController.h in Headers */,
+				7AFE44F71B7E6F5900570689 /* AESampleRateConverter.h in Headers */,
 				7A5687271B5461BE00243427 /* AEAudioController+Audiobus.h in Headers */,
 				7A5687291B5461BE00243427 /* AEAudioFilePlayer.h in Headers */,
 				7A56872A1B5461BE00243427 /* AEAudioFileWriter.h in Headers */,
@@ -440,6 +450,7 @@
 				4C99588616BB74720011FB01 /* AEAudioUnitChannel.m in Sources */,
 				4C99588E16C0825F0011FB01 /* AEAudioUnitFilter.m in Sources */,
 				4C456B8E16D59365008ED99D /* AEBlockAudioReceiver.m in Sources */,
+				7AFE44F81B7E6F5900570689 /* AESampleRateConverter.m in Sources */,
 				4C09450216FBD7460054608E /* AEBlockScheduler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -462,6 +473,7 @@
 				7A56871F1B54617200243427 /* AEAudioFileLoaderOperation.m in Sources */,
 				7A5687201B54617200243427 /* TPCircularBuffer.c in Sources */,
 				7A5687221B54618B00243427 /* TPCircularBuffer+AudioBufferList.c in Sources */,
+				7AFE44F91B7E6F5900570689 /* AESampleRateConverter.m in Sources */,
 				7A5687211B54617200243427 /* AEBlockScheduler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2936,6 +2936,11 @@ static void interAppConnectedChangeCallback(void *inRefCon, AudioUnit inUnit, Au
     checkResult(DisposeAUGraph(_audioGraph), "DisposeAUGraph");
     _audioGraph = NULL;
     _ioAudioUnit = NULL;
+#if !TARGET_OS_IPHONE
+    checkResult(AudioUnitUninitialize(_iAudioUnit), "AudioUnitUninitialize");
+    checkResult(AudioComponentInstanceDispose(_iAudioUnit), "AudioComponentInstanceDispose");
+    _iAudioUnit = NULL;
+#endif
     
     for ( int i=0; i<_inputCallbackCount; i++ ) {
         if ( _inputCallbacks[i].audioConverter ) {

--- a/TheAmazingAudioEngine/AESampleRateConverter.h
+++ b/TheAmazingAudioEngine/AESampleRateConverter.h
@@ -1,0 +1,79 @@
+//
+//  AESampleRateConverter.h
+//  TheAmazingAudioEngine
+//
+//  Created by Steve Rubin on 8/14/15.
+//  Copyright (c) 2015 A Tasty Pixel. All rights reserved.
+//
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+
+/*!
+ * Universal sample rate converter
+ *
+ *  Use this class to easily convert audio sample rates.
+ */
+@interface AESampleRateConverter : NSObject
+
+/*!
+ * Initialize
+ *
+ * @param sourceFormat The source audio format to use
+ */
+- (id)initWithSourceFormat:(AudioStreamBasicDescription)sourceFormat;
+
+/*!
+ * Convert audio to audio with a different sample rate
+ *
+ *  This C function, safe to use in a Core Audio realtime thread context, will take
+ *  an audio buffer list of audio in the format you provided at initialisation, and
+ *  convert it into a noninterleaved float array.
+ *
+ * @param converter         Pointer to the converter object.
+ * @param sourceBuffer      An audio buffer list containing the source audio.
+ * @param targetBuffers     An array of floating-point arrays to store the resampled audio into.
+ *                          Note that you must provide the correct number of arrays, to match the number of channels.
+ * @param inFrames          The number of frames to convert.
+ * @param outFrames         The number of converted frames in the target buffers, after resampling
+ * @return YES on success; NO on failure
+ */
+BOOL AESampleRateConverterToBuffers(AESampleRateConverter* converter, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 inFrames, UInt32 *outFrames);
+
+/*!
+ * Convert audio to audio with a different sample rate, in a buffer list
+ *
+ *  This C function, safe to use in a Core Audio realtime thread context, will take
+ *  an audio buffer list of audio in the format you provided at initialisation, and
+ *  convert its sample rate to the rate specified in destFormat.
+ *
+ * @param converter         Pointer to the converter object.
+ * @param sourceBuffer      An audio buffer list containing the source audio.
+ * @param targetBuffer      An audio buffer list to store the audio with new destFormat sample rate
+ * @param inFrames          The number of frames to convert.
+ * @param outFrames         The number of converted frames in the target buffer, after resampling
+ * @return YES on success; NO on failure
+ */
+BOOL AESampleRateConverterToBufferList(AESampleRateConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 inFrames, UInt32 *outFrames);
+
+/*!
+ * The AudioStreamBasicDescription representing the resampled format
+ */
+@property (nonatomic, assign) AudioStreamBasicDescription destFormat;
+
+/*!
+ * The source audio format set at initialization
+ */
+@property (nonatomic, assign) AudioStreamBasicDescription sourceFormat;
+
+
+@end
+
+    
+#ifdef __cplusplus
+}
+#endif

--- a/TheAmazingAudioEngine/AESampleRateConverter.m
+++ b/TheAmazingAudioEngine/AESampleRateConverter.m
@@ -1,0 +1,177 @@
+//
+//  AESampleRateConverter.m
+//  TheAmazingAudioEngine
+//
+//  Created by Steve Rubin on 8/14/15.
+//  Copyright (c) 2015 A Tasty Pixel. All rights reserved.
+//
+
+#import "AESampleRateConverter.h"
+
+#define checkResult(result,operation) (_checkResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
+static inline BOOL _checkResult(OSStatus result, const char *operation, const char* file, int line) {
+    if ( result != noErr ) {
+        NSLog(@"%s:%d: %s result %d %08X %4.4s", file, line, operation, (int)result, (int)result, (char*)&result);
+        return NO;
+    }
+    return YES;
+}
+
+#define                        kNoMoreDataErr                            -2222
+
+struct complexInputDataProc_t {
+    AudioBufferList *sourceBuffer;
+};
+
+@interface AESampleRateConverter () {
+    AudioStreamBasicDescription _sourceAudioDescription;
+    AudioStreamBasicDescription _destAudioDescription;
+    AudioConverterRef           _sampleRateConverter;
+    AudioBufferList            *_scratchBufferList;
+}
+
+static OSStatus complexInputDataProc(AudioConverterRef             inAudioConverter,
+                                     UInt32                        *ioNumberDataPackets,
+                                     AudioBufferList               *ioData,
+                                     AudioStreamPacketDescription  **outDataPacketDescription,
+                                     void                          *inUserData);
+
+@end
+
+@implementation AESampleRateConverter
+
+- (id)initWithSourceFormat:(AudioStreamBasicDescription)sourceFormat {
+    if ( !(self = [super init]) ) return nil;
+    
+    self.sourceFormat = sourceFormat;
+    
+    return self;
+}
+
+-(void)setSourceFormat:(AudioStreamBasicDescription)sourceFormat {
+    if ( !memcmp(&sourceFormat, &_sourceAudioDescription, sizeof(sourceFormat)) ) return;
+    
+    _sourceAudioDescription = sourceFormat;
+    
+    [self updateFormats];
+}
+
+- (void)setDestFormat:(AudioStreamBasicDescription)destFormat {
+    if ( !memcmp(&destFormat, &_destAudioDescription, sizeof(destFormat)) ) return;
+    
+    _destAudioDescription = destFormat;
+    
+    [self updateFormats];
+}
+
+- (void)updateFormats {
+    if ( _sampleRateConverter ) {
+        AudioConverterDispose(_sampleRateConverter);
+        _sampleRateConverter = NULL;
+    }
+    
+    if ( _destAudioDescription.mSampleRate == 0 || _sourceAudioDescription.mSampleRate == 0 ) return;
+    
+    if ( memcmp(&_sourceAudioDescription, &_destAudioDescription, sizeof(AudioStreamBasicDescription)) != 0 ) {
+        checkResult(AudioConverterNew(&_sourceAudioDescription, &_destAudioDescription, &_sampleRateConverter), "AudioConverterNew");
+        
+        UInt32 primeMethod;
+        primeMethod = kConverterPrimeMethod_None;
+        checkResult(AudioConverterSetProperty(_sampleRateConverter, kAudioConverterPrimeMethod, sizeof(primeMethod), &primeMethod), "AudioConverterSetProperty(kAudioConverterPrimeMethod)");
+
+        UInt32 quality = kAudioConverterQuality_Max;
+        checkResult(AudioConverterSetProperty(_sampleRateConverter, kAudioConverterSampleRateConverterQuality, sizeof(quality), &quality), "AudioConverterSetProperty(kAudioConverterSampleRateConverterQuality)");
+        
+        UInt32 complexity = kAudioConverterSampleRateConverterComplexity_Mastering;
+        checkResult(AudioConverterSetProperty(_sampleRateConverter, kAudioConverterSampleRateConverterComplexity, sizeof(complexity), &complexity), "AudioConverterSetProperty(kAudioConverterSampleRateConverterComplexity)");
+        
+        _scratchBufferList = (AudioBufferList*)malloc(sizeof(AudioBufferList) + (_sourceAudioDescription.mChannelsPerFrame-1)*sizeof(AudioBuffer));
+        _scratchBufferList->mNumberBuffers = _sourceAudioDescription.mChannelsPerFrame;
+        for ( int i=0; i<_scratchBufferList->mNumberBuffers; i++ ) {
+            _scratchBufferList->mBuffers[i].mNumberChannels = 1;
+        }
+    }
+}
+
+BOOL AESampleRateConverterToBuffers(__unsafe_unretained AESampleRateConverter* THIS, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 inFrames, UInt32 *outFrames) {
+    if ( inFrames == 0 ) return YES;
+    
+    if ( THIS->_sampleRateConverter ) {
+        UInt32 priorDataByteSize = sourceBuffer->mBuffers[0].mDataByteSize;
+        for ( int i=0; i<sourceBuffer->mNumberBuffers; i++ ) {
+            sourceBuffer->mBuffers[i].mDataByteSize = inFrames * THIS->_sourceAudioDescription.mBytesPerFrame;
+        }
+        
+        float rateMultiplier = THIS->_destAudioDescription.mSampleRate / THIS->_sourceAudioDescription.mSampleRate;
+        *outFrames = (UInt32)(inFrames * rateMultiplier) + 1;
+        
+        for ( int i=0; i<THIS->_scratchBufferList->mNumberBuffers; i++ ) {
+            THIS->_scratchBufferList->mBuffers[i].mData = targetBuffers[i];
+            THIS->_scratchBufferList->mBuffers[i].mDataByteSize = *outFrames * sizeof(float);
+        }
+        
+        OSStatus result = AudioConverterFillComplexBuffer(THIS->_sampleRateConverter,
+                                                          complexInputDataProc,
+                                                          &(struct complexInputDataProc_t) { .sourceBuffer = sourceBuffer },
+                                                          &inFrames,
+                                                          THIS->_scratchBufferList,
+                                                          NULL);
+        
+        *outFrames = inFrames;
+        
+        for ( int i=0; i<sourceBuffer->mNumberBuffers; i++ ) {
+            sourceBuffer->mBuffers[i].mDataByteSize = priorDataByteSize;
+        }
+        
+        if ( result != kAudioConverterErr_InvalidInputSize && result != kNoMoreDataErr ) {
+            if ( !checkResult(result, "AudioConverterConvertComplexBuffer") ) {
+                return NO;
+            }
+        }
+        
+    } else {
+        for ( int i=0; i<sourceBuffer->mNumberBuffers; i++ ) {
+            memcpy(targetBuffers[i], sourceBuffer->mBuffers[i].mData, inFrames * sizeof(float));
+        }
+        *outFrames = inFrames;
+    }
+    
+    return YES;
+}
+
+BOOL AESampleRateConverterToBufferList(__unsafe_unretained AESampleRateConverter* THIS, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 inFrames, UInt32 *outFrames) {
+    assert(targetBuffer->mNumberBuffers == THIS->_sourceAudioDescription.mChannelsPerFrame);
+    
+    float *targetBuffers[targetBuffer->mNumberBuffers];
+    for ( int i=0; i<targetBuffer->mNumberBuffers; i++ ) {
+        targetBuffers[i] = (float*)targetBuffer->mBuffers[i].mData;
+    }
+    return AESampleRateConverterToBuffers(THIS, sourceBuffer, targetBuffers, inFrames, outFrames);
+}
+
+static OSStatus complexInputDataProc(AudioConverterRef             inAudioConverter,
+                                     UInt32                        *ioNumberDataPackets,
+                                     AudioBufferList               *ioData,
+                                     AudioStreamPacketDescription  **outDataPacketDescription,
+                                     void                          *inUserData) {
+    struct complexInputDataProc_t *arg = (struct complexInputDataProc_t*)inUserData;
+    
+    if ( !arg->sourceBuffer ) {
+        return kNoMoreDataErr;
+    }
+    
+    memcpy(ioData, arg->sourceBuffer, sizeof(AudioBufferList) + (arg->sourceBuffer->mNumberBuffers-1)*sizeof(AudioBuffer));
+    arg->sourceBuffer = NULL;
+    
+    // This prevents the kAudioConverterErr_InvalidInputSize error, but leads to other problems
+//    *ioNumberDataPackets = ioData->mBuffers[0].mDataByteSize / sizeof(float);
+
+    return noErr;
+}
+
+- (void)dealloc {
+    if ( _sampleRateConverter ) AudioConverterDispose(_sampleRateConverter);
+    if ( _scratchBufferList ) free(_scratchBufferList);
+}
+
+@end

--- a/TheEngineSample/OS X/ViewController.m
+++ b/TheEngineSample/OS X/ViewController.m
@@ -86,7 +86,7 @@ static const int kInputChannelsChangedContext;
     
     self.inputLevelLayer = [CALayer layer];
     _inputLevelLayer.backgroundColor = [[NSColor colorWithWhite:0.0 alpha:0.3] CGColor];
-    _inputLevelLayer.frame = NSMakeRect(_headerView.bounds.size.width/2.0 - 5.0 - (0.0), 0, 50, 10);
+    _inputLevelLayer.frame = NSMakeRect(_headerView.bounds.size.width/2.0 - 5.0, 0, 50, 10);
     [_headerView.layer addSublayer:_inputLevelLayer];
     
     self.outputLevelLayer = [CALayer layer];
@@ -307,7 +307,7 @@ static inline float translate(float val, float min, float max) {
     [_audioController outputAveragePowerLevel:&outputAvg peakHoldLevel:&outputPeak];
     
     _inputLevelLayer.frame = NSMakeRect(_headerView.bounds.size.width/2.0 - 5.0 - (translate(inputAvg, -20, 0) * (_headerView.bounds.size.width/2.0 - 15.0)),
-                                        90,
+                                        _inputLevelLayer.frame.origin.y,
                                         translate(inputAvg, -20, 0) * (_headerView.bounds.size.width/2.0 - 15.0),
                                         10);
     


### PR DESCRIPTION
If the sample rate of the input doesn't match the sample rate of the output, use an AudioConverter to resample the input audio.

There may still be a bug or two here. I also couldn't test it with any mics sampling at below 44100 Hz (only > 44100 Hz).

If the user has the mic clock set to the same sample rate as the hardware output, we skip this resampling. This should be the case most of the time- there's no reason to have the mic set at a different sample rate than the rate at which you're doing all the processing & output.

Another way to approach this might be to try to set the input device's sample rate to the output rate if possible to try to avoid this resampling whenever possible.