### PR TITLE
Add C function to AEAudioFilePlayer to get playhead, for use in render callbacks

### DIFF
--- a/TheAmazingAudioEngine/AEAudioFilePlayer.h
+++ b/TheAmazingAudioEngine/AEAudioFilePlayer.h
@@ -67,6 +67,9 @@ extern "C" {
 @property (nonatomic, readwrite) BOOL loop;                 //!< Whether to loop this track
 @property (nonatomic, readwrite) BOOL removeUponFinish;     //!< Whether the track automatically removes itself from the audio controller after playback completes
 @property (nonatomic, copy) void(^completionBlock)();       //!< A block to be called when playback finishes
+
+int AEAudioFilePlayerGetPlayhead(AEAudioFilePlayer *filePlayer);
+
 @end
 
 #ifdef __cplusplus

--- a/TheAmazingAudioEngine/AEAudioFilePlayer.m
+++ b/TheAmazingAudioEngine/AEAudioFilePlayer.m
@@ -300,4 +300,8 @@ static void AEAudioFilePlayerNotifyCompletion(__unsafe_unretained AEAudioControl
     }
 }
 
+int AEAudioFilePlayerGetPlayhead(AEAudioFilePlayer *filePlayer) {
+    return filePlayer->_playhead;
+}
+
 @end


### PR DESCRIPTION
If another filter or channel is relying on changing its behavior based on the current time of an AEAudioFilePlayer, it needs a way to do check the player's playhead in a high performance render callback.