### PR TITLE
Return the proper number of frames from the input producer

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -481,6 +481,7 @@ static OSStatus inputAudioProducer(void *userInfo, AudioBufferList *audio, UInt3
         for ( int i=0; i<audio->mNumberBuffers && i<THIS->_inputAudioBufferList->mNumberBuffers; i++ ) {
             audio->mBuffers[i].mDataByteSize = MIN(audio->mBuffers[i].mDataByteSize, THIS->_inputAudioBufferList->mBuffers[i].mDataByteSize);
             memcpy(audio->mBuffers[i].mData, THIS->_inputAudioBufferList->mBuffers[i].mData, audio->mBuffers[i].mDataByteSize);
+            *frames = audio->mBuffers[i].mDataByteSize / THIS->_audioDescription.mBytesPerFrame;
         }
     }
 


### PR DESCRIPTION
Without this, I was getting a failed assertion when I tried to record in the iOS example app. The problem here is that we could set a new audio buffer byte size without returning the correct number of frames from the input producer.