### PR TITLE
Removing AEReverbFilter parameters that do not exist on iOS Reverb Unit

### DIFF
--- a/Modules/Filters/AEReverbFilter.h
+++ b/Modules/Filters/AEReverbFilter.h
@@ -34,13 +34,4 @@
 // range is from 1 to 1000 (unitless). Default is 1.
 @property (nonatomic) double randomizeReflections;
 
-// range is from 10Hz to 20000Hz. Default is 800Hz.
-@property (nonatomic) double filterFrequency;
-
-// range is from 0.05 to 4.0 octaves. Default is 3.0 octaves.
-@property (nonatomic) double filterBandwidth;
-
-// range is from -18dB to 18dB. Default is 0.0dB.
-@property (nonatomic) double filterGain;
-
 @end

--- a/Modules/Filters/AEReverbFilter.m
+++ b/Modules/Filters/AEReverbFilter.m
@@ -48,19 +48,6 @@
     return [self getParameterValueForId:kReverb2Param_RandomizeReflections];
 }
 
-- (double)filterFrequency {
-    return [self getParameterValueForId:kReverbParam_FilterFrequency];
-}
-
-- (double)filterBandwidth {
-    return [self getParameterValueForId:kReverbParam_FilterBandwidth];
-}
-
-- (double)filterGain {
-    return [self getParameterValueForId:kReverbParam_FilterGain];
-}
-
-
 #pragma mark - Setters
 
 - (void)setDryWetMix:(double)dryWetMix {
@@ -96,21 +83,6 @@
 - (void)setRandomizeReflections:(double)randomizeReflections {
     [self setParameterValue: randomizeReflections
                       forId: kReverb2Param_RandomizeReflections];
-}
-
-- (void)setFilterFrequency:(double)filterFrequency {
-    [self setParameterValue: filterFrequency
-                      forId: kReverbParam_FilterFrequency];
-}
-
-- (void)setFilterBandwidth:(double)filterBandwidth {
-    [self setParameterValue: filterBandwidth
-                      forId: kReverbParam_FilterBandwidth];
-}
-
-- (void)setFilterGain:(double)filterGain {
-    [self setParameterValue: filterGain
-                      forId: kReverbParam_FilterGain];
 }
 
 @end


### PR DESCRIPTION
- The **kReverbParam_FilterFrequency**, **kReverbParam_FilterBandwidth**, and **kReverbParam_FilterGain** parameters do not exist on the iOS Reverb Unit (assuming this is also true for mac os). Therefore, when attempting to set any of those 3 parameters on an AEReverbFilter object, the **AudioUnitSetParameter: -10878** OSStatus code is spit out in the console log.

- From www.osstatus.com -> code **-10878** corresponds to **kAudioUnitErr_InvalidParameter**

- From the AudioUnits doc -> the aforementioned 3 properties correspond to "Reverb parameters applicable to AUSpatialMixer"