### PR TITLE
Update graph after removing nodes in releaseResourcesForGroup

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -3811,6 +3811,8 @@ static void removeChannelsFromGroup(__unsafe_unretained AEAudioController *THIS,
             [self releaseResourcesForChannel:group->channels[i]];
         }
     }
+
+    AECheckOSStatus([self updateGraph], "Update graph");
     
     free(group);
 }


### PR DESCRIPTION
I was seeing some graph update errors in certain cases. With a liberal usage of `CAShow(_audioGraph)`, I figured out that in some cases if, say:

node 1 (out bus) ---> (in bus) node 2

TAAE could schedule removal of node 1 and _then_ disconnection on the input bus of node 2. This is an error in CoreAudio- you can't disconnect a connection that doesn't exist.

A fix here is to update the graph after scheduling the removal of the node.