### PR TITLE
Fixed race condition in audiobusConnectionsChanged

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -2362,7 +2362,7 @@ AudioTimeStamp AEAudioControllerCurrentAudioTimestamp(__unsafe_unretained AEAudi
     if ( _inputEnabled ) {
         [self updateInputDeviceStatus];
     }
-    if ( [(id<AEAudiobusForwardDeclarationsProtocol>)notification.object connected] && !self.running ) {
+    if ( [(id<AEAudiobusForwardDeclarationsProtocol>)notification.object connected] && !_started ) {
         [self start:NULL];
     }
 }


### PR DESCRIPTION
If an app is connected to Audiobus while the `AEAudioController` is stopped, it attempts to start itself. Previously, it would check `!self.running` and call `start:` if necessary. However, in some situations, the main `ioAudioUnit` may already be running even though the engine is stopped (possibly started indirectly by Inter-App Audio?). This PR changes the check from `!self.running` to `!_started` to ensure the AudioGraph and `AEMessageQueue` poll thread are properly started.